### PR TITLE
Improve publish/unpublish and add pytest for CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ artifacts
 mypy.xml
 pylint.xml
 builder.yml
+test.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,8 @@ pytest:
   coverage: '/TOTAL.*\s(\d+)%/'
   variables:
     PYTHONPATH: .
+  before_script:
+    - sudo dnf install -y python3-pathspec
   script:
     - docker build -f dockerfiles/fedora.Dockerfile -t qubes-builder-fedora .
     - pytest-3 -v --color=yes --cov qubesbuilder --cov-report term --cov-report html:artifacts/htmlcov --cov-report xml:artifacts/coverage.xml --junitxml=artifacts/qubesbuilder.xml tests/

--- a/dockerfiles/debian.Dockerfile
+++ b/dockerfiles/debian.Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Frédéric Pierret <frederic@invisiblethingslab.com>
 
 # Install dependencies for Qubes Builder
 RUN apt-get update && \
-    apt-get install -y debootstrap devscripts dpkg-dev git wget python3-debian\
+    apt-get install -y debootstrap devscripts dpkg-dev git wget python3-debian e2fsprogs \
     && apt-get clean all
 
 RUN mkdir /builder /builder/plugins /builder/build

--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Frédéric Pierret <frederic@invisiblethingslab.com>
 # Install dependencies for Qubes Builder
 RUN dnf -y update && \
     dnf install -y createrepo_c debootstrap devscripts dpkg-dev git mock pbuilder \
-        which perl-Digest-MD5 perl-Digest-SHA python3-pyyaml \
+        which perl-Digest-MD5 perl-Digest-SHA python3-pyyaml e2fsprogs \
         python3-sh rpm-build rpmdevtools wget python3-debian reprepro systemd-udev \
     && dnf clean all
 

--- a/example-configs/builder-devel.yml
+++ b/example-configs/builder-devel.yml
@@ -96,15 +96,15 @@ repository-upload-remote-host:
   rpm: user@qubes.notset.fr/repo/notset/rpm/
   deb: user@qubes.notset.fr/repo/notset/deb/
 
-#executor:
-#  type: docker
-#  options:
-#    image: "qubes-builder-fedora:latest"
-
 executor:
-  type: qubes
+  type: docker
   options:
-    dispvm: "qubes-builder-dvm"
+    image: "qubes-builder-fedora:latest"
+
+#executor:
+#  type: qubes
+#  options:
+#    dispvm: "qubes-builder-dvm"
 
 stages:
   - fetch:

--- a/example-configs/builder-devel.yml
+++ b/example-configs/builder-devel.yml
@@ -96,15 +96,15 @@ repository-upload-remote-host:
   rpm: user@qubes.notset.fr/repo/notset/rpm/
   deb: user@qubes.notset.fr/repo/notset/deb/
 
-executor:
-  type: docker
-  options:
-    image: "qubes-builder-fedora:latest"
-
 #executor:
-#  type: qubes
+#  type: docker
 #  options:
-#    dispvm: "qubes-builder-dvm"
+#    image: "qubes-builder-fedora:latest"
+
+executor:
+  type: qubes
+  options:
+    dispvm: "qubes-builder-dvm"
 
 stages:
   - fetch:

--- a/example-configs/builder-devel.yml
+++ b/example-configs/builder-devel.yml
@@ -49,6 +49,16 @@ templates:
 artifacts-dir: /home/user/qubes-builderv2/artifacts
 
 components:
+  - vmm-xen:
+      url: https://github.com/fepitre/qubes-vmm-xen
+      branch: builderv2
+      maintainers:
+        - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
+  - core-libvirt:
+      url: https://github.com/fepitre/qubes-core-libvirt
+      branch: builderv2
+      maintainers:
+        - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
   - python-qasync:
       url: https://github.com/fepitre/qubes-python-qasync
       branch: builderv2
@@ -71,6 +81,8 @@ components:
         - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
 
 less-secure-signed-commits-sufficient:
+  - vmm-xen
+  - core-libvirt
   - python-qasync
   - core-vchan-xen
   - core-qrexec

--- a/example-configs/builder-devel.yml
+++ b/example-configs/builder-devel.yml
@@ -96,15 +96,16 @@ repository-upload-remote-host:
   rpm: user@qubes.notset.fr/repo/notset/rpm/
   deb: user@qubes.notset.fr/repo/notset/deb/
 
-#executor:
-#  type: docker
-#  options:
-#    image: "qubes-builder-fedora:latest"
-
 executor:
-  type: qubes
+  type: docker
   options:
-    dispvm: "qubes-builder-dvm"
+    image: "qubes-builder-fedora:latest"
+#    clean: false
+
+#executor:
+#  type: qubes
+#  options:
+#    dispvm: "qubes-builder-dvm"
 
 stages:
   - fetch:

--- a/qubesbuilder/cli/cli_base.py
+++ b/qubesbuilder/cli/cli_base.py
@@ -51,7 +51,7 @@ class AliasedGroup(click.Group):
         super().__init__(*args, **kwargs)
         self.aliases = {}
         self.debug = False
-        self.list_commands = self.list_commands_for_help
+        self.list_commands = self.list_commands_for_help  # type: ignore
 
     def __call__(self, *args, **kwargs):
         try:

--- a/qubesbuilder/cli/cli_main.py
+++ b/qubesbuilder/cli/cli_main.py
@@ -27,10 +27,9 @@ import click
 
 from qubesbuilder.cli.cli_base import ContextObj, aliased_group
 from qubesbuilder.cli.cli_package import package
-from qubesbuilder.cli.cli_template import template
 from qubesbuilder.cli.cli_repository import repository
+from qubesbuilder.cli.cli_template import template
 from qubesbuilder.config import Config, STAGES
-from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.log import get_logger, init_logging
 
 log = get_logger("cli")

--- a/qubesbuilder/cli/cli_package.py
+++ b/qubesbuilder/cli/cli_package.py
@@ -2,6 +2,7 @@ import click
 
 from qubesbuilder.config import STAGES, STAGES_ALIAS
 from qubesbuilder.cli.cli_base import aliased_group, ContextObj
+from qubesbuilder.plugins.source import FetchPlugin
 from qubesbuilder.plugins.helpers import (
     getSourcePlugin,
     getBuildPlugin,
@@ -27,6 +28,19 @@ def _component_stage(obj: ContextObj, stage_name: str):
     executor = obj.config.get_stages()[stage_name]["executor"]
 
     for component in obj.components:
+        # Component plugins
+        fetch_plugin = FetchPlugin(
+            component=component,
+            plugins_dir=obj.config.get_plugins_dir(),
+            executor=executor,
+            artifacts_dir=obj.config.get_artifacts_dir(),
+            verbose=obj.config.verbose,
+            debug=obj.config.debug,
+            skip_if_exists=obj.config.get("reuse-fetched-source", False),
+        )
+        fetch_plugin.run(stage=stage_name)
+
+        # Distribution plugins
         for dist in obj.distributions:
             plugins = [
                 getSourcePlugin(

--- a/qubesbuilder/cli/cli_repository.py
+++ b/qubesbuilder/cli/cli_repository.py
@@ -11,24 +11,12 @@ def repository():
     """
 
 
-#
-# Publish
-#
-
-
-@click.command(
-    name="publish",
-    short_help="Publish packages or templates to provided repository.",
-)
-@click.argument("repository_publish", nargs=1)
-@click.option(
-    "--ignore-min-age",
-    default=False,
-    is_flag=True,
-    help="Override minimum age for authorizing publication into 'current'.",
-)
-@click.pass_obj
-def publish(obj: ContextObj, repository_publish: str, ignore_min_age: bool = False):
+def _publish(
+    obj: ContextObj,
+    repository_publish: str,
+    ignore_min_age: bool = False,
+    unpublish: bool = False,
+):
     executor = obj.config.get_stages()["publish"]["executor"]
     if repository_publish in (
         "current",
@@ -55,6 +43,7 @@ def publish(obj: ContextObj, repository_publish: str, ignore_min_age: bool = Fal
                     stage="publish",
                     repository_publish=repository_publish,
                     ignore_min_age=ignore_min_age,
+                    unpublish=unpublish,
                 )
     elif repository_publish in (
         "templates-itl",
@@ -79,7 +68,47 @@ def publish(obj: ContextObj, repository_publish: str, ignore_min_age: bool = Fal
                 stage="publish",
                 repository_publish=repository_publish,
                 ignore_min_age=ignore_min_age,
+                unpublish=unpublish,
             )
 
 
+#
+# Publish
+#
+
+
+@click.command(
+    name="publish",
+    short_help="Publish packages or templates to provided repository.",
+)
+@click.argument("repository_publish", nargs=1)
+@click.option(
+    "--ignore-min-age",
+    default=False,
+    is_flag=True,
+    help="Override minimum age for authorizing publication into 'current'.",
+)
+@click.pass_obj
+def publish(obj: ContextObj, repository_publish: str, ignore_min_age: bool = False):
+    _publish(
+        obj=obj, repository_publish=repository_publish, ignore_min_age=ignore_min_age
+    )
+
+
+#
+# Unpublish
+#
+
+
+@click.command(
+    name="unpublish",
+    short_help="Unpublish packages or templates from provided repository.",
+)
+@click.argument("repository_publish", nargs=1)
+@click.pass_obj
+def unpublish(obj: ContextObj, repository_publish: str):
+    _publish(obj=obj, repository_publish=repository_publish, unpublish=True)
+
+
 repository.add_command(publish)
+repository.add_command(unpublish)

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -83,6 +83,9 @@ class Config:
     def get(self, key, default=None):
         return self._conf.get(key, default)
 
+    def set(self, key, value):
+        self._conf[key] = value
+
     def get_distributions(self, filtered_distributions=None):
         if not self._dists:
             if filtered_distributions:

--- a/qubesbuilder/executors/container.py
+++ b/qubesbuilder/executors/container.py
@@ -119,8 +119,13 @@ class ContainerExecutor(Executor):
                 if self._container_client == "podman":
                     for k, v in environment.copy().items():
                         environment[k] = str(v)
+                volumes = ["/dev/loop-control"]
                 container = client.containers.create(
-                    image, cmd, privileged=True, environment=environment
+                    image,
+                    cmd,
+                    privileged=True,
+                    environment=environment,
+                    volumes=volumes,
                 )
 
                 # Adjust log namespace

--- a/qubesbuilder/executors/container.py
+++ b/qubesbuilder/executors/container.py
@@ -119,7 +119,12 @@ class ContainerExecutor(Executor):
                 if self._container_client == "podman":
                     for k, v in environment.copy().items():
                         environment[k] = str(v)
-                volumes = ["/dev/loop-control"]
+                if self._container_client == "podman":
+                    volumes = {
+                        "loop-control": {"bind": "/dev/loop-control", "mode": "rw"}
+                    }
+                else:
+                    volumes = ["/dev/loop-control"]  # type: ignore
                 container = client.containers.create(
                     image,
                     cmd,

--- a/qubesbuilder/executors/helpers.py
+++ b/qubesbuilder/executors/helpers.py
@@ -7,11 +7,11 @@ from qubesbuilder.executors.qubes import QubesExecutor
 def getExecutor(executor_type, executor_options):
     executor = None
     if executor_type in ("podman", "docker"):
-        executor = ContainerExecutor(executor_type, executor_options.get("image", None))
+        executor = ContainerExecutor(executor_type, **executor_options)
     elif executor_type == "local":
         executor = LocalExecutor()
     elif executor_type == "qubes":
-        executor = QubesExecutor(executor_options.get("dispvm", None))
+        executor = QubesExecutor(**executor_options)
     if not executor:
         raise ExecutorError("Cannot determine which executor to use.")
     return executor

--- a/qubesbuilder/executors/qubes.py
+++ b/qubesbuilder/executors/qubes.py
@@ -108,11 +108,12 @@ class QubesExecutor(Executor):
 
         dispvm = None
         try:
-            result = subprocess.check_output(
+            result = subprocess.run(
                 ["qrexec-client-vm", "dom0", "admin.vm.CreateDisposable"],
+                capture_output=True,
                 stdin=subprocess.DEVNULL,
             )
-            dispvm = result.decode("utf8").replace("0\x00", "")
+            dispvm = result.stdout.decode("utf8").replace("0\x00", "")
             if not re.match(r"disp[0-9]{1,4}", dispvm):
                 raise ExecutorError("Failed to create disposable qube.")
 
@@ -179,4 +180,5 @@ class QubesExecutor(Executor):
                 subprocess.run(
                     ["qrexec-client-vm", dispvm, "admin.vm.Kill"],
                     stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
                 )

--- a/qubesbuilder/executors/qubes.py
+++ b/qubesbuilder/executors/qubes.py
@@ -31,9 +31,10 @@ log = get_logger("executor:qubes")
 
 
 class QubesExecutor(Executor):
-    def __init__(self, dispvm, **kwargs):
+    def __init__(self, dispvm, clean=True, **kwargs):
         # dispvm is the template used for creating a disposable qube.
         self.dispvm = dispvm
+        self._clean = clean
         self._kwargs = kwargs
 
     def copy_in(self, vm: str, source_path: Path, destination_dir: PurePath):
@@ -176,7 +177,7 @@ class QubesExecutor(Executor):
                     raise e
         finally:
             # Kill the DispVM to prevent hanging for while
-            if dispvm:
+            if dispvm and self._clean:
                 subprocess.run(
                     ["qrexec-client-vm", dispvm, "admin.vm.Kill"],
                     stdin=subprocess.DEVNULL,

--- a/qubesbuilder/plugins/__init__.py
+++ b/qubesbuilder/plugins/__init__.py
@@ -224,3 +224,73 @@ class DistributionPlugin(ComponentPlugin):
         except (PermissionError, yaml.YAMLError) as e:
             msg = f"{self.component}:{self.dist}:{basename}: Failed to write info for {stage} stage."
             raise PluginError(msg) from e
+
+
+class RPMDistributionPlugin(DistributionPlugin):
+
+    """
+    RPM distribution component plugin
+    """
+
+    def __init__(
+        self,
+        component: QubesComponent,
+        dist: QubesDistribution,
+        plugins_dir: Path,
+        artifacts_dir: Path,
+        verbose: bool,
+        debug: bool,
+    ):
+        super().__init__(
+            component=component,
+            dist=dist,
+            plugins_dir=plugins_dir,
+            artifacts_dir=artifacts_dir,
+            verbose=verbose,
+            debug=debug,
+        )
+
+        # Per distribution (e.g. host-fc42) overrides per package set (e.g. host)
+        parameters = self.component.get_parameters(self._placeholders)
+
+        self.parameters.update(parameters.get(self.dist.package_set, {}).get("rpm", {}))
+        self.parameters.update(
+            parameters.get(self.dist.distribution, {}).get("rpm", {})
+        )
+
+        self.parameters["spec"] = [
+            PurePath(spec) for spec in self.parameters.get("spec", [])
+        ]
+
+
+class DEBDistributionPlugin(DistributionPlugin):
+
+    """
+    RPM distribution component plugin
+    """
+
+    def __init__(
+        self,
+        component: QubesComponent,
+        dist: QubesDistribution,
+        plugins_dir: Path,
+        artifacts_dir: Path,
+        verbose: bool,
+        debug: bool,
+    ):
+        super().__init__(
+            component=component,
+            dist=dist,
+            plugins_dir=plugins_dir,
+            artifacts_dir=artifacts_dir,
+            verbose=verbose,
+            debug=debug,
+        )
+
+        # Per distribution (e.g. vm-bookworm) overrides per package set (e.g. vm)
+        parameters = self.component.get_parameters(self._placeholders)
+
+        self.parameters.update(parameters.get(self.dist.package_set, {}).get("deb", {}))
+        self.parameters.update(
+            parameters.get(self.dist.distribution, {}).get("deb", {})
+        )

--- a/qubesbuilder/plugins/build/__init__.py
+++ b/qubesbuilder/plugins/build/__init__.py
@@ -23,7 +23,7 @@ from qubesbuilder.component import QubesComponent
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor
 from qubesbuilder.log import get_logger
-from qubesbuilder.plugins import Plugin, PluginError
+from qubesbuilder.plugins import DistributionPlugin, PluginError
 
 log = get_logger("build")
 
@@ -32,7 +32,7 @@ class BuildError(PluginError):
     pass
 
 
-class BuildPlugin(Plugin):
+class BuildPlugin(DistributionPlugin):
     """
     BuildPlugin manages generic distribution build.
     """

--- a/qubesbuilder/plugins/build_deb/__init__.py
+++ b/qubesbuilder/plugins/build_deb/__init__.py
@@ -137,7 +137,7 @@ class DEBBuildPlugin(BuildPlugin):
                 log.info(f"{self.component}: nothing to be done for {self.dist}")
                 return
 
-            artifacts_dir = self.get_component_dir(stage)
+            artifacts_dir = self.get_dist_component_artifacts_dir(stage)
 
             # Clean previous build artifacts
             if artifacts_dir.exists():
@@ -145,7 +145,7 @@ class DEBBuildPlugin(BuildPlugin):
             artifacts_dir.mkdir(parents=True)
 
             # Source artifacts
-            prep_artifacts_dir = self.get_component_dir(stage="prep")
+            prep_artifacts_dir = self.get_dist_component_artifacts_dir(stage="prep")
 
             repository_dir = self.get_repository_dir() / self.dist.distribution
             repository_dir.mkdir(parents=True, exist_ok=True)

--- a/qubesbuilder/plugins/build_deb/__init__.py
+++ b/qubesbuilder/plugins/build_deb/__init__.py
@@ -161,6 +161,10 @@ class DEBBuildPlugin(BuildPlugin, DEBDistributionPlugin):
                 # Build Debian packages
                 #
 
+                for src in ["dsc", "orig", "debian"]:
+                    if not source_info.get(src, None):
+                        raise BuildError(f"Cannot find sources for '{directory}'")
+
                 # Copy-in plugin, repository and sources
                 copy_in = [
                     (self.plugins_dir / "build_deb", PLUGINS_DIR),

--- a/qubesbuilder/plugins/build_deb/__init__.py
+++ b/qubesbuilder/plugins/build_deb/__init__.py
@@ -129,7 +129,7 @@ class DEBBuildPlugin(BuildPlugin, DEBDistributionPlugin):
 
             # Compare previous artifacts hash with current source hash
             if all(
-                self.get_source_hash()
+                self.component.get_source_hash()
                 == self.get_artifacts_info(stage, directory).get("source-hash", None)
                 for directory in self.parameters["build"]
             ):
@@ -286,5 +286,5 @@ class DEBBuildPlugin(BuildPlugin, DEBDistributionPlugin):
                 # Save package information we parsed for next stages
                 info = source_info
                 info["packages"] = packages_list
-                info["source-hash"] = self.get_source_hash()
+                info["source-hash"] = self.component.get_source_hash()
                 self.save_artifacts_info(stage=stage, basename=directory, info=info)

--- a/qubesbuilder/plugins/build_rpm/__init__.py
+++ b/qubesbuilder/plugins/build_rpm/__init__.py
@@ -141,7 +141,7 @@ class RPMBuildPlugin(BuildPlugin, RPMDistributionPlugin):
 
             # Compare previous artifacts hash with current source hash
             if all(
-                self.get_source_hash()
+                self.component.get_source_hash()
                 == self.get_artifacts_info(stage, spec.with_suffix("").name).get(
                     "source-hash", None
                 )
@@ -265,6 +265,6 @@ class RPMBuildPlugin(BuildPlugin, RPMDistributionPlugin):
                 info = {
                     "srpm": source_info["srpm"],
                     "rpms": packages_list,
-                    "source-hash": self.get_source_hash(),
+                    "source-hash": self.component.get_source_hash(),
                 }
                 self.save_artifacts_info(stage=stage, basename=spec_bn, info=info)

--- a/qubesbuilder/plugins/build_rpm/__init__.py
+++ b/qubesbuilder/plugins/build_rpm/__init__.py
@@ -146,7 +146,7 @@ class RPMBuildPlugin(BuildPlugin):
                 return
 
             distfiles_dir = self.get_distfiles_dir()
-            artifacts_dir = self.get_component_dir(stage)
+            artifacts_dir = self.get_dist_component_artifacts_dir(stage)
             rpms_dir = artifacts_dir / "rpm"
 
             # Clean previous build artifacts
@@ -155,7 +155,7 @@ class RPMBuildPlugin(BuildPlugin):
             rpms_dir.mkdir(parents=True)
 
             # Source artifacts
-            prep_artifacts_dir = self.get_component_dir(stage="prep")
+            prep_artifacts_dir = self.get_dist_component_artifacts_dir(stage="prep")
 
             # Local build repository
             repository_dir = self.get_repository_dir() / self.dist.distribution

--- a/qubesbuilder/plugins/build_rpm/__init__.py
+++ b/qubesbuilder/plugins/build_rpm/__init__.py
@@ -214,6 +214,7 @@ class RPMBuildPlugin(BuildPlugin, RPMDistributionPlugin):
                 mock_cmd = [
                     f"sudo --preserve-env=DIST,PACKAGE_SET,USE_QUBES_REPO_VERSION",
                     f"/usr/libexec/mock/mock",
+                    "--isolation=simple",
                     f"--rebuild {BUILD_DIR / source_info['srpm']}",
                     f"--root /builder/plugins/source_rpm/mock/{mock_conf}",
                     f"--resultdir={BUILD_DIR}",

--- a/qubesbuilder/plugins/build_rpm/__init__.py
+++ b/qubesbuilder/plugins/build_rpm/__init__.py
@@ -22,11 +22,10 @@ import shutil
 from pathlib import Path
 from typing import List
 
-import yaml
-
 from qubesbuilder.component import QubesComponent
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor, ExecutorError
+from qubesbuilder.executors.qubes import QubesExecutor
 from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import (
     BUILDER_DIR,
@@ -214,11 +213,14 @@ class RPMBuildPlugin(BuildPlugin, RPMDistributionPlugin):
                 mock_cmd = [
                     f"sudo --preserve-env=DIST,PACKAGE_SET,USE_QUBES_REPO_VERSION",
                     f"/usr/libexec/mock/mock",
-                    "--isolation=simple",
                     f"--rebuild {BUILD_DIR / source_info['srpm']}",
                     f"--root /builder/plugins/source_rpm/mock/{mock_conf}",
                     f"--resultdir={BUILD_DIR}",
                 ]
+                if isinstance(self.executor, QubesExecutor):
+                    mock_cmd.append("--isolation=nspawn")
+                else:
+                    mock_cmd.append("--isolation=simple")
                 if self.verbose:
                     mock_cmd.append("--verbose")
                 if self.use_qubes_repo and self.use_qubes_repo.get("version"):

--- a/qubesbuilder/plugins/publish/__init__.py
+++ b/qubesbuilder/plugins/publish/__init__.py
@@ -24,7 +24,7 @@ from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor
 from qubesbuilder.executors.local import LocalExecutor
 from qubesbuilder.log import get_logger
-from qubesbuilder.plugins import Plugin, PluginError
+from qubesbuilder.plugins import DistributionPlugin, PluginError
 
 log = get_logger("publish")
 
@@ -36,7 +36,7 @@ class PublishError(PluginError):
     pass
 
 
-class PublishPlugin(Plugin):
+class PublishPlugin(DistributionPlugin):
     """
     PublishPlugin manages generic distribution publication.
     """

--- a/qubesbuilder/plugins/publish/__init__.py
+++ b/qubesbuilder/plugins/publish/__init__.py
@@ -101,17 +101,11 @@ class PublishPlugin(DistributionPlugin):
 
     def can_be_published_in_stable(self, basename, ignore_min_age):
         # Check packages are published
-        publish_info = self.get_artifacts_info(stage="publish", basename=basename)
-        if not publish_info:
-            return False
-
-        # Check for valid repositories under which packages are published
-        if "current-testing" not in [
-            r["name"] for r in publish_info.get("repository-publish", [])
-        ]:
+        if not self.is_published(basename, "current-testing"):
             return False
 
         # Check minimum day that packages are available for testing
+        publish_info = self.get_artifacts_info(stage="publish", basename=basename)
         publish_date = None
         for r in publish_info["repository-publish"]:
             if r["name"] == "current-testing":

--- a/qubesbuilder/plugins/publish/__init__.py
+++ b/qubesbuilder/plugins/publish/__init__.py
@@ -17,6 +17,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import datetime
+import os
 from pathlib import Path
 
 from qubesbuilder.component import QubesComponent
@@ -75,3 +77,45 @@ class PublishPlugin(DistributionPlugin):
     def run(self, stage: str):
         if stage == "publish" and not isinstance(self.executor, LocalExecutor):
             raise PublishError("This plugin only supports local executor.")
+
+    def is_published_in_stable(self, basename, ignore_min_age):
+        failure_msg = (
+            f"{self.component}:{self.dist}:{basename}: "
+            f"Refusing to publish to 'current' as packages are not "
+            f"uploaded to 'current-testing' or 'security-testing' "
+            f"for at least {MIN_AGE_DAYS} days."
+        )
+        # Check packages are published
+        publish_info = self.get_artifacts_info(stage="publish", basename=basename)
+        if not publish_info:
+            raise PublishError(failure_msg)
+
+        # Check for valid repositories under which packages are published
+        if publish_info.get("repository-publish", None) not in (
+            "security-testing",
+            "current-testing",
+            "current",
+        ):
+            raise PublishError(failure_msg)
+        # If publish repository is 'current' we check the next spec file
+        if publish_info["repository-publish"] == "current":
+            log.info(
+                f"{self.component}:{self.dist}:{basename}: "
+                f"Already published to 'current'."
+            )
+            return True
+
+        # Check minimum day that packages are available for testing
+        publish_date = datetime.datetime.utcfromtimestamp(
+            os.stat(
+                self.get_dist_component_artifacts_dir("publish")
+                / f"{basename}.publish.yml"
+            ).st_mtime
+        )
+        # Check that packages have been published before threshold_date
+        threshold_date = datetime.datetime.utcnow() - datetime.timedelta(
+            days=MIN_AGE_DAYS
+        )
+        if not ignore_min_age and publish_date > threshold_date:
+            raise PublishError(failure_msg)
+        return False

--- a/qubesbuilder/plugins/publish_deb/__init__.py
+++ b/qubesbuilder/plugins/publish_deb/__init__.py
@@ -22,12 +22,13 @@ from qubesbuilder.component import QubesComponent
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor, ExecutorError
 from qubesbuilder.log import get_logger
+from qubesbuilder.plugins import DEBDistributionPlugin
 from qubesbuilder.plugins.publish import PublishPlugin, PublishError
 
 log = get_logger("publish_deb")
 
 
-class DEBPublishPlugin(PublishPlugin):
+class DEBPublishPlugin(PublishPlugin, DEBDistributionPlugin):
     """
     DEGBPublishPlugin manages DEB distribution publication.
     """
@@ -62,19 +63,6 @@ class DEBPublishPlugin(PublishPlugin):
             debug=debug,
         )
 
-    def update_parameters(self):
-        """
-        Update plugin parameters based on component .qubesbuilder.
-        """
-        super().update_parameters()
-
-        # Per distribution (e.g. vm-bookworm) overrides per package set (e.g. vm)
-        parameters = self.component.get_parameters(self._placeholders)
-        self.parameters.update(parameters.get(self.dist.package_set, {}).get("deb", {}))
-        self.parameters.update(
-            parameters.get(self.dist.distribution, {}).get("deb", {})
-        )
-
     def run(
         self, stage: str, repository_publish: str = None, ignore_min_age: bool = False
     ):
@@ -83,9 +71,6 @@ class DEBPublishPlugin(PublishPlugin):
         """
         # Run stage defined by parent class
         super().run(stage=stage)
-
-        # Update parameters
-        self.update_parameters()
 
         # Check if we have Debian related content defined
         if not self.parameters.get("build", []):

--- a/qubesbuilder/plugins/publish_deb/__init__.py
+++ b/qubesbuilder/plugins/publish_deb/__init__.py
@@ -234,7 +234,7 @@ class DEBPublishPlugin(PublishPlugin):
                         cmd += [f"gpg2 -q --homedir {keyring_dir} --verify {fname}"]
                     self.executor.run(cmd)
                 except ExecutorError as e:
-                    msg = f"{self.component}:{self.dist}:{directory}: Failed to sign packages."
+                    msg = f"{self.component}:{self.dist}:{directory}: Failed to check signatures."
                     raise PublishError(msg) from e
 
                 # Publishing packages

--- a/qubesbuilder/plugins/publish_deb/__init__.py
+++ b/qubesbuilder/plugins/publish_deb/__init__.py
@@ -111,12 +111,14 @@ class DEBPublishPlugin(PublishPlugin):
                 return
 
             # Build artifacts (source included)
-            build_artifacts_dir = self.get_component_dir(stage="build")
+            build_artifacts_dir = self.get_dist_component_artifacts_dir(stage="build")
             # Sign artifacts
-            sign_artifacts_dir = self.get_component_dir(stage="sign")
+            sign_artifacts_dir = self.get_dist_component_artifacts_dir(stage="sign")
             keyring_dir = sign_artifacts_dir / "keyring"
             # Publish artifacts
-            publish_artifacts_dir = self.get_component_dir(stage="publish")
+            publish_artifacts_dir = self.get_dist_component_artifacts_dir(
+                stage="publish"
+            )
             # repository-publish directory
             artifacts_dir = self.get_repository_publish_dir() / self.dist.type
 

--- a/qubesbuilder/plugins/publish_rpm/__init__.py
+++ b/qubesbuilder/plugins/publish_rpm/__init__.py
@@ -116,13 +116,15 @@ class RPMPublishPlugin(PublishPlugin):
                 return
 
             # Source artifacts
-            prep_artifacts_dir = self.get_component_dir(stage="prep")
+            prep_artifacts_dir = self.get_dist_component_artifacts_dir(stage="prep")
             # Build artifacts
-            build_artifacts_dir = self.get_component_dir(stage="build")
+            build_artifacts_dir = self.get_dist_component_artifacts_dir(stage="build")
             # Sign artifacts
-            sign_artifacts_dir = self.get_component_dir(stage="sign")
+            sign_artifacts_dir = self.get_dist_component_artifacts_dir(stage="sign")
             # Publish artifacts
-            publish_artifacts_dir = self.get_component_dir(stage="publish")
+            publish_artifacts_dir = self.get_dist_component_artifacts_dir(
+                stage="publish"
+            )
             # repository-publish directory
             artifacts_dir = self.get_repository_publish_dir() / self.dist.type
 

--- a/qubesbuilder/plugins/publish_rpm/__init__.py
+++ b/qubesbuilder/plugins/publish_rpm/__init__.py
@@ -18,6 +18,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import os
 import shutil
+from datetime import datetime
 from pathlib import Path
 
 from qubesbuilder.component import QubesComponent
@@ -25,7 +26,7 @@ from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor, ExecutorError
 from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import RPMDistributionPlugin
-from qubesbuilder.plugins.publish import PublishPlugin, PublishError
+from qubesbuilder.plugins.publish import PublishPlugin, PublishError, MIN_AGE_DAYS
 
 log = get_logger("publish_rpm")
 
@@ -65,14 +66,151 @@ class RPMPublishPlugin(PublishPlugin, RPMDistributionPlugin):
             debug=debug,
         )
 
+    def createrepo(self, spec, target_dir):
+        log.info(f"{self.component}:{self.dist}:{spec}: Updating metadata.")
+        cmd = [f"cd {target_dir}", "createrepo_c -g comps.xml ."]
+        try:
+            shutil.rmtree(target_dir / "repodata")
+            self.executor.run(cmd)
+        except (ExecutorError, OSError) as e:
+            msg = f"{self.component}:{self.dist}:{spec}: Failed to 'createrepo_c'"
+            raise PublishError(msg) from e
+
+    def sign_metadata(self, spec, sign_key, target_dir):
+        log.info(f"{self.component}:{self.dist}:{spec}: Signing metadata.")
+        repomd = target_dir / "repodata/repomd.xml"
+        cmd = [
+            f"{self.gpg_client} --batch --no-tty --yes --detach-sign --armor -u {sign_key} {repomd} > {repomd}.asc",
+        ]
+        try:
+            self.executor.run(cmd)
+        except (ExecutorError, OSError) as e:
+            msg = f"{self.component}:{self.dist}:{spec}:  Failed to sign metadata"
+            raise PublishError(msg) from e
+
+    def publish(self, spec, sign_key, db_path, repository_publish):
+        # spec file basename will be used as prefix for some artifacts
+        spec_bn = spec.with_suffix("").name
+
+        # Read information from build stage
+        build_info = self.get_artifacts_info(stage="build", basename=spec_bn)
+
+        if not build_info.get("rpms", []) and not build_info.get("srpm", None):
+            log.info(f"{self.component}:{self.dist}:{spec}: Nothing to publish.")
+            return
+
+        # Publish packages with hardlinks to built RPMs
+        log.info(
+            f"{self.component}:{self.dist}:{spec}: Publishing RPMs to '{repository_publish}'."
+        )
+
+        # Source artifacts
+        prep_artifacts_dir = self.get_dist_component_artifacts_dir(stage="prep")
+        # Build artifacts
+        build_artifacts_dir = self.get_dist_component_artifacts_dir(stage="build")
+        # Publish repository
+        artifacts_dir = self.get_repository_publish_dir() / self.dist.type
+
+        packages_list = [
+            build_artifacts_dir / "rpm" / rpm for rpm in build_info["rpms"]
+        ]
+        packages_list += [prep_artifacts_dir / build_info["srpm"]]
+
+        # We check that signature exists (--check-only option)
+        log.info(f"{self.component}:{self.dist}:{spec}: Verifying signatures.")
+        try:
+            for rpm in packages_list:
+                cmd = [
+                    f"{self.plugins_dir}/sign_rpm/scripts/sign-rpm "
+                    f"--sign-key {sign_key} --db-path {db_path} --rpm {rpm} --check-only"
+                ]
+                self.executor.run(cmd)
+        except ExecutorError as e:
+            msg = f"{self.component}:{self.dist}:{spec}: Failed to check signatures."
+            raise PublishError(msg) from e
+
+        target_dir = (
+            artifacts_dir
+            / f"{self.qubes_release}/{repository_publish}/{self.dist.package_set}/{self.dist.name}"
+        )
+        try:
+            for rpm in packages_list:
+                target_path = target_dir / "rpm" / rpm.name
+                target_path.unlink(missing_ok=True)
+                # target_path.hardlink_to(rpm)
+                os.link(rpm, target_path)
+        except (ValueError, PermissionError, NotImplementedError) as e:
+            msg = f"{self.component}:{self.dist}:{spec}: Failed to publish packages."
+            raise PublishError(msg) from e
+
+        # Createrepo published RPMs
+        self.createrepo(spec=spec, target_dir=target_dir)
+
+        # Sign metadata
+        self.sign_metadata(spec=spec, sign_key=sign_key, target_dir=target_dir)
+
+    def unpublish(self, spec, sign_key, repository_publish):
+        # spec file basename will be used as prefix for some artifacts
+        spec_bn = os.path.basename(spec).replace(".spec", "")
+        # Read information from build stage
+        build_info = self.get_artifacts_info(stage="build", basename=spec_bn)
+
+        if not build_info.get("rpms", []) and not build_info.get("srpm", None):
+            log.info(f"{self.component}:{self.dist}:{spec}: Nothing to unpublish.")
+            return
+
+        log.info(
+            f"{self.component}:{self.dist}:{spec}: Unpublishing RPMs from '{repository_publish}'."
+        )
+
+        # Source artifacts
+        prep_artifacts_dir = self.get_dist_component_artifacts_dir(stage="prep")
+        # Build artifacts
+        build_artifacts_dir = self.get_dist_component_artifacts_dir(stage="build")
+
+        packages_list = [
+            build_artifacts_dir / "rpm" / rpm for rpm in build_info["rpms"]
+        ]
+        packages_list += [prep_artifacts_dir / build_info["srpm"]]
+
+        # If exists, remove hardlinks to built RPMs
+        artifacts_dir = self.get_repository_publish_dir() / self.dist.type
+        target_dir = (
+            artifacts_dir
+            / f"{self.qubes_release}/{repository_publish}/{self.dist.package_set}/{self.dist.name}"
+        )
+        try:
+            for rpm in packages_list:
+                target_path = target_dir / "rpm" / rpm.name
+                target_path.unlink(missing_ok=True)
+        except (ValueError, PermissionError, NotImplementedError) as e:
+            msg = f"{self.component}:{self.dist}:{spec}: Failed to unpublish packages."
+            raise PublishError(msg) from e
+
+        # Createrepo unpublished RPMs
+        self.createrepo(spec=spec, target_dir=target_dir)
+
+        # Sign metadata
+        self.sign_metadata(spec=spec, sign_key=sign_key, target_dir=target_dir)
+
     def run(
-        self, stage: str, repository_publish: str = None, ignore_min_age: bool = False
+        self,
+        stage: str,
+        repository_publish: str = None,
+        ignore_min_age: bool = False,
+        unpublish: bool = False,
+        **kwargs,
     ):
         """
         Run plugging for given stage.
         """
         # Run stage defined by parent class
         super().run(stage=stage)
+
+        # Check if we have RPM related content defined
+        if not self.parameters.get("spec", []):
+            log.info(f"{self.component}:{self.dist}: Nothing to be done.")
+            return
 
         # Check if we have a signing key provided
         sign_key = self.sign_key.get(self.dist.distribution, None) or self.sign_key.get(
@@ -90,23 +228,15 @@ class RPMPublishPlugin(PublishPlugin, RPMDistributionPlugin):
         # FIXME: Refactor the code handling both standard and template components.
         #  It applies for other plugins.
 
-        # Publish stage for standard (not template) components
-        if stage == "publish":
-            # Check if we have RPM related content defined
-            if not self.parameters.get("spec", []):
-                log.info(f"{self.component}:{self.dist}: Nothing to be done.")
-                return
+        repository_publish = repository_publish or self.repository_publish.get(
+            "components", "current-testing"
+        )
 
-            # Source artifacts
-            prep_artifacts_dir = self.get_dist_component_artifacts_dir(stage="prep")
-            # Build artifacts
-            build_artifacts_dir = self.get_dist_component_artifacts_dir(stage="build")
+        # Publish stage for standard (not template) components
+        if stage == "publish" and not unpublish:
             # Sign artifacts
             sign_artifacts_dir = self.get_dist_component_artifacts_dir(stage="sign")
-            # Publish artifacts
-            publish_artifacts_dir = self.get_dist_component_artifacts_dir(
-                stage="publish"
-            )
+
             # repository-publish directory
             artifacts_dir = self.get_repository_publish_dir() / self.dist.type
 
@@ -137,25 +267,12 @@ class RPMPublishPlugin(PublishPlugin, RPMDistributionPlugin):
                 raise PublishError(msg) from e
 
             # Check if publish repository is valid
-            if not repository_publish:
-                repository_publish = self.repository_publish.get(
-                    "components", "current-testing"
-                )
-            if repository_publish not in (
-                "current",
-                "current-testing",
-                "security-testing",
-                "unstable",
-            ):
-                msg = (
-                    f"{self.component}:{self.dist}: "
-                    f"Refusing to publish components into '{repository_publish}'."
-                )
-                raise PublishError(msg)
+            self.validate_repository_publish(repository_publish)
 
-            if repository_publish == "current" and all(
-                self.is_published_in_stable(
-                    basename=spec, ignore_min_age=ignore_min_age
+            # Check if we already published packages into the provided repository
+            if all(
+                self.is_published(
+                    basename=spec.with_suffix("").name, repository=repository_publish
                 )
                 for spec in self.parameters["spec"]
             ):
@@ -164,83 +281,92 @@ class RPMPublishPlugin(PublishPlugin, RPMDistributionPlugin):
                 )
                 return
 
+            # Check if we can publish into current
+            if repository_publish == "current" and not all(
+                self.can_be_published_in_stable(
+                    basename=spec.with_suffix("").name, ignore_min_age=ignore_min_age
+                )
+                for spec in self.parameters["spec"]
+            ):
+                failure_msg = (
+                    f"{self.component}:{self.dist}: "
+                    f"Refusing to publish to 'current' as packages are not "
+                    f"uploaded to 'current-testing' or 'security-testing' "
+                    f"for at least {MIN_AGE_DAYS} days."
+                )
+                raise PublishError(failure_msg)
+
             for spec in self.parameters["spec"]:
-                # spec file basename will be used as prefix for some artifacts
                 spec_bn = spec.with_suffix("").name
-
-                # Read information from build stage
                 build_info = self.get_artifacts_info(stage="build", basename=spec_bn)
+                publish_info = self.get_artifacts_info(stage=stage, basename=spec_bn)
 
-                if not build_info.get("rpms", []) and not build_info.get("srpm", None):
-                    log.info(
-                        f"{self.component}:{self.dist}:{spec}: Nothing to publish."
-                    )
-                    continue
+                # If previous publication to a repo has been done and does not correspond to current
+                # build artifacts, we delete previous publications. It happens if we modify local
+                # sources and then publish into repository with the same version and release.
+                info = build_info
+                if publish_info:
+                    if build_info["source-hash"] != publish_info["source-hash"]:
+                        for repository in publish_info.get("repository-publish", []):
+                            self.unpublish(
+                                spec=spec,
+                                sign_key=sign_key,
+                                repository_publish=repository,
+                            )
+                    else:
+                        info = publish_info
 
-                packages_list = [
-                    build_artifacts_dir / "rpm" / rpm for rpm in build_info["rpms"]
-                ]
-                packages_list += [prep_artifacts_dir / build_info["srpm"]]
-
-                # We check that signature exists (--check-only option)
-                log.info(f"{self.component}:{self.dist}:{spec}: Verifying signatures.")
-                try:
-                    for rpm in packages_list:
-                        cmd = [
-                            f"{self.plugins_dir}/sign_rpm/scripts/sign-rpm "
-                            f"--sign-key {sign_key} --db-path {db_path} --rpm {rpm} --check-only"
-                        ]
-                        self.executor.run(cmd)
-                except ExecutorError as e:
-                    msg = f"{self.component}:{self.dist}:{spec}: Failed to check signatures."
-                    raise PublishError(msg) from e
-
-                # Publish packages with hardlinks to built RPMs
-                log.info(
-                    f"{self.component}:{self.dist}:{spec}: Publishing RPMs to '{repository_publish}'."
+                self.publish(
+                    spec=spec,
+                    sign_key=sign_key,
+                    db_path=db_path,
+                    repository_publish=repository_publish,
                 )
-                artifacts_dir = self.get_repository_publish_dir() / self.dist.type
-                target_dir = (
-                    artifacts_dir
-                    / f"{self.qubes_release}/{repository_publish}/{self.dist.package_set}/{self.dist.name}"
-                )
-                try:
-                    for rpm in packages_list:
-                        target_path = target_dir / "rpm" / rpm.name
-                        target_path.unlink(missing_ok=True)
-                        # target_path.hardlink_to(rpm)
-                        os.link(rpm, target_path)
-                except (ValueError, PermissionError, NotImplementedError) as e:
-                    msg = f"{self.component}:{self.dist}:{spec}: Failed to publish packages."
-                    raise PublishError(msg) from e
-
-                # Createrepo published RPMs
-                log.info(f"{self.component}:{self.dist}:{spec}: Updating metadata.")
-                cmd = [f"cd {target_dir}", "createrepo_c -g comps.xml ."]
-                try:
-                    shutil.rmtree(target_dir / "repodata")
-                    self.executor.run(cmd)
-                except (ExecutorError, OSError) as e:
-                    msg = (
-                        f"{self.component}:{self.dist}:{spec}: Failed to 'createrepo_c'"
-                    )
-                    raise PublishError(msg) from e
-
-                # Sign metadata
-                log.info(f"{self.component}:{self.dist}:{spec}: Signing metadata.")
-                repomd = target_dir / "repodata/repomd.xml"
-                cmd = [
-                    f"{self.gpg_client} --batch --no-tty --yes --detach-sign --armor -u {sign_key} {repomd} > {repomd}.asc",
-                ]
-                try:
-                    self.executor.run(cmd)
-                except (ExecutorError, OSError) as e:
-                    msg = (
-                        f"{self.component}:{self.dist}:{spec}:  Failed to sign metadata"
-                    )
-                    raise PublishError(msg) from e
 
                 # Save package information we published for committing into current
-                info = build_info
-                info["repository-publish"] = repository_publish
+                info.setdefault("repository-publish", []).append(
+                    {
+                        "name": repository_publish,
+                        "timestamp": datetime.utcnow().strftime("%Y%m%d%H%MZ"),
+                    }
+                )
                 self.save_artifacts_info(stage="publish", basename=spec_bn, info=info)
+
+        if stage == "publish" and unpublish:
+            if not all(
+                self.is_published(
+                    basename=spec.with_suffix("").name, repository=repository_publish
+                )
+                for spec in self.parameters["spec"]
+            ):
+                log.info(
+                    f"{self.component}:{self.dist}: Not published to '{repository_publish}'."
+                )
+                return
+
+            for spec in self.parameters["spec"]:
+                spec_bn = spec.with_suffix("").name
+                publish_info = self.get_artifacts_info(stage=stage, basename=spec_bn)
+
+                self.unpublish(
+                    spec=spec,
+                    sign_key=sign_key,
+                    repository_publish=repository_publish,
+                )
+
+                # Save package information we published for committing into current. If the packages
+                # are not published into another repository, we delete the publish stage information.
+                publish_info["repository-publish"] = [
+                    r
+                    for r in publish_info.get("repository-publish", [])
+                    if r["name"] != repository_publish
+                ]
+                if publish_info.get("repository-publish", []):
+                    self.save_artifacts_info(
+                        stage="publish", basename=spec_bn, info=publish_info
+                    )
+                else:
+                    log.info(
+                        f"{self.component}:{self.dist}:{spec_bn}: Not published anywhere else, deleting publish info."
+                    )
+                    self.delete_artifacts_info(stage="publish", basename=spec_bn)

--- a/qubesbuilder/plugins/sign/__init__.py
+++ b/qubesbuilder/plugins/sign/__init__.py
@@ -24,7 +24,7 @@ from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor
 from qubesbuilder.executors.local import LocalExecutor
 from qubesbuilder.log import get_logger
-from qubesbuilder.plugins import Plugin, PluginError
+from qubesbuilder.plugins import DistributionPlugin, PluginError
 
 log = get_logger("sign")
 
@@ -33,7 +33,7 @@ class SignError(PluginError):
     pass
 
 
-class SignPlugin(Plugin):
+class SignPlugin(DistributionPlugin):
     """
     SignPlugin manages generic distribution sign.
     """

--- a/qubesbuilder/plugins/sign_deb/__init__.py
+++ b/qubesbuilder/plugins/sign_deb/__init__.py
@@ -24,6 +24,7 @@ from qubesbuilder.component import QubesComponent
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor, ExecutorError
 from qubesbuilder.log import get_logger
+from qubesbuilder.plugins import DEBDistributionPlugin
 from qubesbuilder.plugins.build import BuildError
 from qubesbuilder.plugins.build_deb import provision_local_repository
 from qubesbuilder.plugins.sign import SignPlugin, SignError
@@ -31,7 +32,7 @@ from qubesbuilder.plugins.sign import SignPlugin, SignError
 log = get_logger("sign_deb")
 
 
-class DEBSignPlugin(SignPlugin):
+class DEBSignPlugin(SignPlugin, DEBDistributionPlugin):
     """
     DEBSignPlugin manages DEB distribution sign.
     """
@@ -62,19 +63,6 @@ class DEBSignPlugin(SignPlugin):
             debug=debug,
         )
 
-    def update_parameters(self):
-        """
-        Update plugin parameters based on component .qubesbuilder.
-        """
-        super().update_parameters()
-
-        # Per distribution (e.g. vm-bookworm) overrides per package set (e.g. vm)
-        parameters = self.component.get_parameters(self._placeholders)
-        self.parameters.update(parameters.get(self.dist.package_set, {}).get("deb", {}))
-        self.parameters.update(
-            parameters.get(self.dist.distribution, {}).get("deb", {})
-        )
-
     def run(self, stage: str):
         """
         Run plugging for given stage.
@@ -83,9 +71,6 @@ class DEBSignPlugin(SignPlugin):
         super().run(stage=stage)
 
         if stage == "sign":
-            # Update parameters
-            self.update_parameters()
-
             # Check if we have Debian related content defined
             if not self.parameters.get("build", []):
                 log.info(f"{self.component}:{self.dist}: Nothing to be done.")

--- a/qubesbuilder/plugins/sign_deb/__init__.py
+++ b/qubesbuilder/plugins/sign_deb/__init__.py
@@ -20,8 +20,6 @@
 import shutil
 from pathlib import Path
 
-import yaml
-
 from qubesbuilder.component import QubesComponent
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor, ExecutorError
@@ -132,8 +130,7 @@ class DEBSignPlugin(SignPlugin):
 
             for directory in self.parameters["build"]:
                 # Read information from build stage
-                with open(build_artifacts_dir / f"{directory}_build_info.yml") as f:
-                    build_info = yaml.safe_load(f.read())
+                build_info = self.get_artifacts_info(stage="build", basename=directory)
 
                 if not build_info.get("changes", None):
                     log.info(

--- a/qubesbuilder/plugins/sign_deb/__init__.py
+++ b/qubesbuilder/plugins/sign_deb/__init__.py
@@ -107,9 +107,9 @@ class DEBSignPlugin(SignPlugin):
                 return
 
             # Build artifacts (source included)
-            build_artifacts_dir = self.get_component_dir(stage="build")
+            build_artifacts_dir = self.get_dist_component_artifacts_dir(stage="build")
             # Sign artifacts
-            artifacts_dir = self.get_component_dir(stage)
+            artifacts_dir = self.get_dist_component_artifacts_dir(stage)
 
             if artifacts_dir.exists():
                 shutil.rmtree(artifacts_dir)

--- a/qubesbuilder/plugins/sign_rpm/__init__.py
+++ b/qubesbuilder/plugins/sign_rpm/__init__.py
@@ -109,11 +109,11 @@ class RPMSignPlugin(SignPlugin):
                 return
 
             # Source artifacts
-            prep_artifacts_dir = self.get_component_dir(stage="prep")
+            prep_artifacts_dir = self.get_dist_component_artifacts_dir(stage="prep")
             # Build artifacts
-            build_artifacts_dir = self.get_component_dir(stage="build")
+            build_artifacts_dir = self.get_dist_component_artifacts_dir(stage="build")
             # Sign artifacts
-            artifacts_dir = self.get_component_dir(stage)
+            artifacts_dir = self.get_dist_component_artifacts_dir(stage)
 
             # We ensure to create a clean keyring for RPM
             if artifacts_dir.exists():

--- a/qubesbuilder/plugins/sign_rpm/__init__.py
+++ b/qubesbuilder/plugins/sign_rpm/__init__.py
@@ -21,8 +21,6 @@ import os
 import shutil
 from pathlib import Path
 
-import yaml
-
 from qubesbuilder.component import QubesComponent
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor, ExecutorError
@@ -136,8 +134,7 @@ class RPMSignPlugin(SignPlugin):
                 spec_bn = os.path.basename(spec).replace(".spec", "")
 
                 # Read information from build stage
-                with open(build_artifacts_dir / f"{spec_bn}_build_info.yml") as f:
-                    build_info = yaml.safe_load(f.read())
+                build_info = self.get_artifacts_info(stage="build", basename=spec_bn)
 
                 if not build_info.get("rpms", []) and not build_info.get("srpm", None):
                     log.info(f"{self.component}:{self.dist}:{spec}: Nothing to sign.")

--- a/qubesbuilder/plugins/sign_rpm/scripts/sign-rpm
+++ b/qubesbuilder/plugins/sign_rpm/scripts/sign-rpm
@@ -73,6 +73,6 @@ if [ "$(rpmkeys --dbpath="$DB_PATH" --checksig -- "$RPM")" != "$RPM: digests sig
     setsid -w rpmsign ${RPMSIGN_OPTS} --addsign -- "$RPM" </dev/null || exit 1
 else
     if [ "$CHECK_ONLY" != "1" ]; then
-        echo "INFO: RPM has already a valid signature. Skipping..."
+        echo "INFO: $(basename "$RPM") has already a valid signature. Skipping..."
     fi
 fi

--- a/qubesbuilder/plugins/source/__init__.py
+++ b/qubesbuilder/plugins/source/__init__.py
@@ -211,13 +211,10 @@ class SourcePlugin(DistributionPlugin):
         self.executor = executor
         self.skip_if_exists = skip_if_exists
 
-    def update_parameters(self):
-        """
-        Update plugin parameters based on component .qubesbuilder.
-        """
         # Set and update parameters based on top-level "source",
         # per package set and per distribution.
         parameters = self.component.get_parameters(self._placeholders)
+
         self.parameters.update(parameters.get("source", {}))
         self.parameters.update(
             parameters.get(self.dist.package_set, {}).get("source", {})

--- a/qubesbuilder/plugins/source/__init__.py
+++ b/qubesbuilder/plugins/source/__init__.py
@@ -177,8 +177,9 @@ class SourcePlugin(Plugin):
                     ]
                 if file.get("signature", None):
                     download_verify_cmd += ["--signature-url", file["signature"]]
-                if file.get("pubkey", None):
-                    download_verify_cmd += ["--pubkey-file", file["pubkey"]]
+                if file.get("pubkeys", None):
+                    for pubkey in file["pubkeys"]:
+                        download_verify_cmd += ["--pubkey-file", pubkey]
                 cmd = [
                     f"cd {str(BUILDER_DIR / self.component.name)}",
                     " ".join(download_verify_cmd),

--- a/qubesbuilder/plugins/source/scripts/download-and-verify-file
+++ b/qubesbuilder/plugins/source/scripts/download-and-verify-file
@@ -43,6 +43,8 @@ fi
 
 eval set -- "$OPTS"
 
+PUBKEY_FILE=()
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -h | --help) usage ;;
@@ -50,7 +52,7 @@ while [[ $# -gt 0 ]]; do
         -c | --checksum-file ) FILE_CHECKSUM="$2"; shift ;;
         -m | --checksum-cmd ) CHECKSUM_CMD="$2"; shift ;;
         -s | --signature-url ) SIGNATURE_URL="$2"; shift ;;
-        -p | --pubkey-file ) PUBKEY_FILE="$2"; shift ;;
+        -p | --pubkey-file ) PUBKEY_FILE+=("$2"); shift ;;
         -o | --output-dir ) OUTPUT_DIR="$2"; shift ;;
     esac
     shift
@@ -63,7 +65,7 @@ fi
 FETCH_CMD=(curl --proto '=https' --proto-redir '=https' --tlsv1.2 --http1.1 -sSfL -o)
 FILE_NAME="$(basename "$FILE_URL")"
 
-if [ -z "${FILE_CHECKSUM}" ] && [ -z "${SIGNATURE_URL}" ] && [ -z "${PUBKEY_FILE}" ]; then
+if [ -z "${FILE_CHECKSUM}" ] && [ -z "${SIGNATURE_URL}" ] && [ -z "${PUBKEY_FILE[*]}" ]; then
     echo "ERROR: Please provide either CHECKSUM or SIGNATURE_URL and PUBKEY_FILE."
     exit 1
 fi
@@ -107,7 +109,9 @@ elif [ -n "${SIGNATURE_URL}" ] && [ -n "${PUBKEY_FILE}" ]; then
 
     # Import pubkey
     keyring="$(mktemp -u)"
-    gpg --no-auto-check-trustdb --no-default-keyring --keyring "$keyring" -q --import "${PUBKEY_FILE}"
+    for pubkey_file in "${PUBKEY_FILE[@]}"; do
+        gpg --no-auto-check-trustdb --no-default-keyring --keyring "$keyring" -q --import "${pubkey_file}"
+    done
 
     # Verify file
     gpgv --keyring "$keyring" "${SIGNATURE_FILE_NAME}" "${FILE_NAME}.untrusted" 2>/dev/null

--- a/qubesbuilder/plugins/source_deb/__init__.py
+++ b/qubesbuilder/plugins/source_deb/__init__.py
@@ -28,13 +28,19 @@ from qubesbuilder.component import QubesComponent
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor, ExecutorError
 from qubesbuilder.log import get_logger
-from qubesbuilder.plugins import BUILDER_DIR, PLUGINS_DIR, BUILD_DIR, DISTFILES_DIR
+from qubesbuilder.plugins import (
+    BUILDER_DIR,
+    PLUGINS_DIR,
+    BUILD_DIR,
+    DISTFILES_DIR,
+    DEBDistributionPlugin,
+)
 from qubesbuilder.plugins.source import SourcePlugin, SourceError
 
 log = get_logger("source_deb")
 
 
-class DEBSourcePlugin(SourcePlugin):
+class DEBSourcePlugin(SourcePlugin, DEBDistributionPlugin):
     """
     Manage Debian distribution source.
 
@@ -75,19 +81,6 @@ class DEBSourcePlugin(SourcePlugin):
             }
         )
 
-    def update_parameters(self):
-        """
-        Update plugin parameters based on component .qubesbuilder.
-        """
-        super().update_parameters()
-
-        # Per distribution (e.g. vm-bookworm) overrides per package set (e.g. vm)
-        parameters = self.component.get_parameters(self._placeholders)
-        self.parameters.update(parameters.get(self.dist.package_set, {}).get("deb", {}))
-        self.parameters.update(
-            parameters.get(self.dist.distribution, {}).get("deb", {})
-        )
-
     def run(self, stage: str):
         """
         Run plugging for given stage.
@@ -96,9 +89,6 @@ class DEBSourcePlugin(SourcePlugin):
         super().run(stage=stage)
 
         if stage == "prep":
-            # Update parameters
-            self.update_parameters()
-
             # Check if we have Debian related content defined
             if not self.parameters.get("build", None):
                 log.info(f"{self.component}: nothing to be done for {self.dist}")

--- a/qubesbuilder/plugins/source_deb/__init__.py
+++ b/qubesbuilder/plugins/source_deb/__init__.py
@@ -104,7 +104,7 @@ class DEBSourcePlugin(SourcePlugin):
                 return
 
             distfiles_dir = self.get_distfiles_dir()
-            artifacts_dir = self.get_component_dir(stage)
+            artifacts_dir = self.get_dist_component_artifacts_dir(stage)
             artifacts_dir.mkdir(parents=True, exist_ok=True)
 
             for directory in self.parameters["build"]:

--- a/qubesbuilder/plugins/source_deb/__init__.py
+++ b/qubesbuilder/plugins/source_deb/__init__.py
@@ -99,7 +99,7 @@ class DEBSourcePlugin(SourcePlugin, DEBDistributionPlugin):
 
             # Compare previous artifacts hash with current source hash
             if all(
-                self.get_source_hash()
+                self.component.get_source_hash()
                 == self.get_artifacts_info(stage, directory).get("source-hash", None)
                 for directory in self.parameters["build"]
             ):
@@ -261,7 +261,7 @@ class DEBSourcePlugin(SourcePlugin, DEBDistributionPlugin):
                         "dsc": source_dsc,
                         "debian": source_debian,
                         "packages": packages_list,
-                        "source-hash": self.get_source_hash(),
+                        "source-hash": self.component.get_source_hash(),
                     }
                     self.save_artifacts_info(stage=stage, basename=directory, info=info)
 

--- a/qubesbuilder/plugins/source_rpm/__init__.py
+++ b/qubesbuilder/plugins/source_rpm/__init__.py
@@ -105,7 +105,7 @@ class RPMSourcePlugin(SourcePlugin):
                 return
 
             distfiles_dir = self.get_distfiles_dir()
-            artifacts_dir = self.get_component_dir(stage)
+            artifacts_dir = self.get_dist_component_artifacts_dir(stage)
             artifacts_dir.mkdir(parents=True, exist_ok=True)
 
             for spec in self.parameters["spec"]:

--- a/qubesbuilder/plugins/source_rpm/__init__.py
+++ b/qubesbuilder/plugins/source_rpm/__init__.py
@@ -18,14 +18,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
-from pathlib import Path
-
 import shutil
+from pathlib import Path
 
 from qubesbuilder.common import is_filename_valid
 from qubesbuilder.component import QubesComponent
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import Executor, ExecutorError
+from qubesbuilder.executors.qubes import QubesExecutor
 from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import (
     BUILDER_DIR,
@@ -215,7 +215,6 @@ class RPMSourcePlugin(SourcePlugin, RPMDistributionPlugin):
                 mock_cmd = [
                     f"sudo --preserve-env=DIST,PACKAGE_SET,USE_QUBES_REPO_VERSION",
                     f"/usr/libexec/mock/mock",
-                    "--isolation=simple",
                     "--buildsrpm",
                     f"--spec {source_dir / spec}",
                     f"--root /builder/plugins/source_rpm/mock/{mock_conf}",
@@ -223,6 +222,10 @@ class RPMSourcePlugin(SourcePlugin, RPMDistributionPlugin):
                     f"--resultdir={BUILD_DIR}",
                     "--disablerepo=builder-local",
                 ]
+                if isinstance(self.executor, QubesExecutor):
+                    mock_cmd.append("--isolation=nspawn")
+                else:
+                    mock_cmd.append("--isolation=simple")
                 if self.verbose:
                     mock_cmd.append("--verbose")
 

--- a/qubesbuilder/plugins/source_rpm/__init__.py
+++ b/qubesbuilder/plugins/source_rpm/__init__.py
@@ -215,6 +215,7 @@ class RPMSourcePlugin(SourcePlugin, RPMDistributionPlugin):
                 mock_cmd = [
                     f"sudo --preserve-env=DIST,PACKAGE_SET,USE_QUBES_REPO_VERSION",
                     f"/usr/libexec/mock/mock",
+                    "--isolation=simple",
                     "--buildsrpm",
                     f"--spec {source_dir / spec}",
                     f"--root /builder/plugins/source_rpm/mock/{mock_conf}",

--- a/qubesbuilder/plugins/source_rpm/__init__.py
+++ b/qubesbuilder/plugins/source_rpm/__init__.py
@@ -99,7 +99,7 @@ class RPMSourcePlugin(SourcePlugin, RPMDistributionPlugin):
 
             # Compare previous artifacts hash with current source hash
             if all(
-                self.get_source_hash()
+                self.component.get_source_hash()
                 == self.get_artifacts_info(stage, spec.with_suffix("").name).get(
                     "source-hash", None
                 )
@@ -239,7 +239,7 @@ class RPMSourcePlugin(SourcePlugin, RPMDistributionPlugin):
                     info = {
                         "srpm": source_rpm,
                         "rpms": packages_list,
-                        "source-hash": self.get_source_hash(),
+                        "source-hash": self.component.get_source_hash(),
                     }
                     self.save_artifacts_info(stage=stage, basename=spec_bn, info=info)
 

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -36,7 +36,7 @@ from qubesbuilder.plugins import (
     REPOSITORY_DIR,
     PLUGINS_DIR,
 )
-from qubesbuilder.plugins.publish_rpm import MIN_AGE_DAYS
+from qubesbuilder.plugins.publish import MIN_AGE_DAYS
 from qubesbuilder.template import QubesTemplate
 
 log = get_logger("template")
@@ -149,8 +149,6 @@ class TemplatePlugin(Plugin):
     def run(
         self, stage: str, repository_publish: str = None, ignore_min_age: bool = False
     ):
-        # Update parameters
-        self.update_parameters()
 
         repository_dir = self.get_repository_dir() / self.dist.distribution
         template_artifacts_dir = self.get_templates_dir()

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -29,7 +29,7 @@ from dateutil.parser import parse as parsedate
 from qubesbuilder.executors import Executor, ExecutorError
 from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import (
-    BasePlugin,
+    Plugin,
     PluginError,
     BUILD_DIR,
     CACHE_DIR,
@@ -54,7 +54,7 @@ class TemplateError(PluginError):
     pass
 
 
-class TemplatePlugin(BasePlugin):
+class TemplatePlugin(Plugin):
     """
     TemplatePlugin manages distribution build.
     """
@@ -76,12 +76,12 @@ class TemplatePlugin(BasePlugin):
         use_qubes_repo: dict = None,
     ):
         super().__init__(
-            dist=template.distribution,
             plugins_dir=plugins_dir,
             artifacts_dir=artifacts_dir,
             verbose=verbose,
             debug=debug,
         )
+        self.dist = template.distribution
         self.template = template
         self.executor = executor
         self.qubes_release = qubes_release
@@ -92,6 +92,8 @@ class TemplatePlugin(BasePlugin):
 
         self.environment.update(
             {
+                "DIST": self.dist.name,  # legacy value
+                "DISTRIBUTION": self.dist.fullname,  # legacy value
                 "DIST_CODENAME": self.dist.name,  # DIST
                 "DIST_NAME": self.dist.fullname,  # DISTRIBUTION
                 "DIST_VER": self.dist.version,

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -17,10 +17,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import datetime
 import os
 import shutil
+from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Dict
 
 import dateutil.parser
 import yaml
@@ -113,6 +114,34 @@ class TemplatePlugin(Plugin):
             }
         )
 
+    def get_artifacts_info(self, stage: str) -> Dict:
+        fileinfo = self.get_templates_dir() / f"{self.template.name}.{stage}.yml"
+        if fileinfo.exists():
+            try:
+                with open(fileinfo, "r") as f:
+                    artifacts_info = yaml.safe_load(f.read())
+                return artifacts_info or {}
+            except (PermissionError, yaml.YAMLError) as e:
+                msg = f"{self.template}: Failed to read info from {stage} stage."
+                raise PluginError(msg) from e
+        return {}
+
+    def save_artifacts_info(self, stage: str, info: dict):
+        artifacts_dir = self.get_templates_dir()
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(artifacts_dir / f"{self.template}.{stage}.yml", "w") as f:
+                f.write(yaml.safe_dump(info))
+        except (PermissionError, yaml.YAMLError) as e:
+            msg = f"{self.template}: Failed to write info for {stage} stage."
+            raise PluginError(msg) from e
+
+    def delete_artifacts_info(self, stage: str):
+        artifacts_dir = self.get_templates_dir()
+        info_path = artifacts_dir / f"{self.template}.{stage}.yml"
+        if info_path.exists():
+            info_path.unlink()
+
     def get_sign_key(self):
         # Check if we have a signing key provided
         sign_key = self.sign_key.get(self.dist.distribution, None) or self.sign_key.get(
@@ -129,22 +158,163 @@ class TemplatePlugin(Plugin):
         return sign_key
 
     def get_template_timestamp(self):
-        # Read information from build stage
-        if not (
-            self.get_templates_dir() / f"build_timestamp_{self.template.name}"
-        ).exists():
-            raise TemplateError(f"{self.template}: Cannot find build timestamp.")
-        with open(
-            self.get_templates_dir() / f"build_timestamp_{self.template.name}"
-        ) as f:
-            data = f.read().splitlines()
+        if not self.template.timestamp:
+            # Read information from build stage
+            if not (
+                self.get_templates_dir() / f"build_timestamp_{self.template.name}"
+            ).exists():
+                raise TemplateError(f"{self.template}: Cannot find build timestamp.")
+            with open(
+                self.get_templates_dir() / f"build_timestamp_{self.template.name}"
+            ) as f:
+                data = f.read().splitlines()
 
+            try:
+                self.template.timestamp = parsedate(data[0]).strftime("%Y%m%d%H%MZ")
+            except (dateutil.parser.ParserError, IndexError) as e:
+                msg = f"{self.template}: Failed to parse build timestamp format."
+                raise TemplateError(msg) from e
+        return self.template.timestamp
+
+    def createrepo(self, target_dir):
+        log.info(f"{self.template}: Updating metadata.")
+        cmd = [f"cd {target_dir}", "createrepo_c ."]
         try:
-            template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%MZ")
-        except (dateutil.parser.ParserError, IndexError) as e:
-            msg = f"{self.template}: Failed to parse build timestamp format."
+            shutil.rmtree(target_dir / "repodata")
+            self.executor.run(cmd)
+        except (ExecutorError, OSError) as e:
+            msg = f"{self.template}: Failed to 'createrepo_c'"
             raise TemplateError(msg) from e
-        return template_timestamp
+
+    def sign_metadata(self, sign_key, target_dir):
+        log.info(f"{self.template}: Signing metadata.")
+        repomd = target_dir / "repodata/repomd.xml"
+        cmd = [
+            f"{self.gpg_client} --batch --no-tty --yes --detach-sign --armor -u {sign_key} {repomd} > {repomd}.asc",
+        ]
+        try:
+            self.executor.run(cmd)
+        except (ExecutorError, OSError) as e:
+            msg = f"{self.template}: Failed to sign metadata"
+            raise TemplateError(msg) from e
+
+    @staticmethod
+    def validate_repository_publish(repository_publish):
+        if repository_publish not in TEMPLATE_REPOSITORIES:
+            raise TemplateError(
+                f"Invalid repository for template: '{repository_publish}'"
+            )
+
+    def is_published(self, repository):
+        publish_info = self.get_artifacts_info("publish")
+        if not publish_info:
+            return False
+        return repository in [
+            r["name"] for r in publish_info.get("repository-publish", [])
+        ]
+
+    def can_be_published_in_stable(self, repository_publish, ignore_min_age):
+        # Check template is published in testing: it is expected templates-itl-testing or
+        # templates-community-testing.
+        if not self.is_published(f"{repository_publish}-testing"):
+            return False
+
+        # Check minimum day that packages are available for testing
+        publish_info = self.get_artifacts_info("publish")
+        publish_date = None
+        for r in publish_info["repository-publish"]:
+            if r["name"] == f"{repository_publish}-testing":
+                publish_date = datetime.strptime(r["timestamp"], "%Y%m%d%H%MZ")
+                break
+
+        if publish_date is None:
+            raise TemplateError(
+                "Something wrong detected in repositories. Missing timestamp?"
+            )
+
+        # Check that packages have been published before threshold_date
+        threshold_date = datetime.utcnow() - timedelta(days=MIN_AGE_DAYS)
+        if not ignore_min_age and publish_date > threshold_date:
+            return False
+
+        return True
+
+    def publish(self, db_path, repository_publish):
+        # Read information from build stage
+        template_timestamp = self.get_template_timestamp()
+
+        rpm = (
+            self.get_templates_dir()
+            / "rpm"
+            / f"qubes-template-{self.template.name}-{TEMPLATE_VERSION}-{template_timestamp}.noarch.rpm"
+        )
+        if not rpm.exists():
+            msg = f"{self.template}: Cannot find template RPM '{rpm}'."
+            raise TemplateError(msg)
+
+        # We check that signature exists (--check-only option)
+        log.info(f"{self.template}: Verifying signatures.")
+        sign_key = self.get_sign_key()
+        try:
+            cmd = [
+                f"{self.plugins_dir}/sign_rpm/scripts/sign-rpm "
+                f"--sign-key {sign_key} --db-path {db_path} --rpm {rpm} --check-only"
+            ]
+            self.executor.run(cmd)
+        except ExecutorError as e:
+            msg = f"{self.template}: Failed to check signatures."
+            raise TemplateError(msg) from e
+
+        # Publish template with hardlinks to built RPM
+        log.info(f"{self.template}: Publishing template.")
+        artifacts_dir = self.get_repository_publish_dir() / self.dist.type
+        target_dir = artifacts_dir / f"{self.qubes_release}/{repository_publish}"
+        try:
+            target_path = target_dir / "rpm" / rpm.name
+            target_path.unlink(missing_ok=True)
+            # target_path.hardlink_to(rpm)
+            os.link(rpm, target_path)
+        except (ValueError, PermissionError, NotImplementedError) as e:
+            msg = f"{self.template}: Failed to publish template."
+            raise TemplateError(msg) from e
+
+        # Createrepo published templates
+        self.createrepo(target_dir)
+
+        # Sign metadata
+        self.sign_metadata(sign_key, target_dir)
+
+    def unpublish(self, repository_publish):
+        # Read information from build stage
+        template_timestamp = self.get_template_timestamp()
+
+        rpm = (
+            self.get_templates_dir()
+            / "rpm"
+            / f"qubes-template-{self.template.name}-{TEMPLATE_VERSION}-{template_timestamp}.noarch.rpm"
+        )
+        if not rpm.exists():
+            msg = f"{self.template}: Cannot find template RPM '{rpm}'."
+            raise TemplateError(msg)
+
+        sign_key = self.get_sign_key()
+
+        # If exists, remove hardlinks to built RPMs
+        log.info(f"{self.template}: Unpublishing template.")
+        artifacts_dir = self.get_repository_publish_dir() / self.dist.type
+        target_dir = artifacts_dir / f"{self.qubes_release}/{repository_publish}"
+        try:
+            target_path = target_dir / "rpm" / rpm.name
+            target_path.unlink(missing_ok=True)
+        except (ValueError, PermissionError, NotImplementedError) as e:
+            msg = f"{self.template}: Failed to unpublish template."
+            raise TemplateError(msg) from e
+
+        # Createrepo unpublished templates
+        self.createrepo(target_dir)
+
+        # Sign metadata
+        self.sign_metadata(sign_key, target_dir)
 
     def run(
         self,
@@ -164,8 +334,16 @@ class TemplatePlugin(Plugin):
         prepared_images.mkdir(parents=True, exist_ok=True)
         qubeized_image.mkdir(parents=True, exist_ok=True)
 
+        repository_publish = repository_publish or self.repository_publish.get(
+            "templates", "templates-itl-testing"
+        )
+
+        #
+        # Prep
+        #
+
         if stage == "prep":
-            template_timestamp = datetime.datetime.utcnow().strftime("%Y%m%d%H%MZ")
+            template_timestamp = datetime.utcnow().strftime("%Y%m%d%H%MZ")
             self.environment.update({"TEMPLATE_TIMESTAMP": template_timestamp})
 
             copy_in = [
@@ -193,6 +371,10 @@ class TemplatePlugin(Plugin):
                 template_artifacts_dir / f"build_timestamp_{self.template.name}", "w"
             ) as f:
                 f.write(template_timestamp)
+
+        #
+        # Build
+        #
 
         if stage == "build":
             template_timestamp = self.get_template_timestamp()
@@ -234,6 +416,10 @@ class TemplatePlugin(Plugin):
                 template_artifacts_dir / f"build_timestamp_{self.template.name}", "w"
             ) as f:
                 f.write(template_timestamp)
+
+        #
+        # Sign
+        #
 
         # Sign stage for templates
         if stage == "sign":
@@ -277,63 +463,35 @@ class TemplatePlugin(Plugin):
                 msg = f"{self.template}: Failed to sign template RPM '{rpm}'."
                 raise TemplateError(msg) from e
 
+        #
+        # Publish
+        #
+
         # Publish stage for template components
-        if stage == "publish":
+        if stage == "publish" and not unpublish:
             # repository-publish directory
             artifacts_dir = self.get_repository_publish_dir() / self.dist.type
 
-            # Check if publish repository is valid
-            if not repository_publish:
-                repository_publish = self.repository_publish.get(
-                    "templates", "current-testing"
-                )
+            self.validate_repository_publish(repository_publish)
 
-            if repository_publish not in TEMPLATE_REPOSITORIES:
-                raise TemplateError(
-                    f"Invalid repository for template: '{repository_publish}'"
+            if self.is_published(repository_publish):
+                log.info(
+                    f"{self.template}: Already published to '{repository_publish}'."
                 )
+                return
 
-            if repository_publish in ("templates-itl", "templates-community"):
+            if repository_publish in (
+                "templates-itl",
+                "templates-community",
+            ) and not self.can_be_published_in_stable(
+                repository_publish, ignore_min_age
+            ):
                 failure_msg = (
                     f"{self.template}: "
                     f"Refusing to publish to '{repository_publish}' as template is not uploaded "
                     f"to '{repository_publish}-testing' for at least {MIN_AGE_DAYS} days."
                 )
-                # Check template is published in testing
-                if not (
-                    template_artifacts_dir / f"{self.template.name}.publish.yml"
-                ).exists():
-                    raise TemplateError(failure_msg)
-
-                # Get existing publish info
-                with open(
-                    template_artifacts_dir / f"{self.template.name}.publish.yml"
-                ) as f:
-                    publish_info = yaml.safe_load(f.read())
-                # Check for valid repositories under which packages are published
-                if (
-                    publish_info.get("repository-publish", None)
-                    not in TEMPLATE_REPOSITORIES
-                ):
-                    raise TemplateError(failure_msg)
-                if publish_info["repository-publish"] == repository_publish:
-                    log.info(
-                        f"{self.template}: Already published to '{repository_publish}'."
-                    )
-                    return
-
-                # Check minimum day that packages are available for testing
-                publish_date = datetime.datetime.utcfromtimestamp(
-                    os.stat(
-                        template_artifacts_dir / f"{self.template.name}.publish.yml"
-                    ).st_mtime
-                )
-                # Check that packages have been published before threshold_date
-                threshold_date = datetime.datetime.utcnow() - datetime.timedelta(
-                    days=MIN_AGE_DAYS
-                )
-                if not ignore_min_age and publish_date > threshold_date:
-                    raise TemplateError(failure_msg)
+                raise TemplateError(failure_msg)
 
             # Ensure dbpath from sign stage (still) exists
             db_path = template_artifacts_dir / "rpmdb"
@@ -362,86 +520,46 @@ class TemplatePlugin(Plugin):
                 msg = f"{self.template}: Failed to create repository skeleton."
                 raise TemplateError(msg) from e
 
-            # Read information from build stage
-            with open(
-                template_artifacts_dir / f"build_timestamp_{self.template.name}"
-            ) as f:
-                data = f.read().splitlines()
+            publish_info = self.get_artifacts_info(stage=stage)
+            info = {"timestamp": self.get_template_timestamp()}
+            if (
+                publish_info
+                and publish_info.get("timestamp", None) == self.get_template_timestamp()
+            ):
+                info = publish_info
 
-            try:
-                timestamp = parsedate(data[0]).strftime("%Y%m%d%H%MZ")
-            except (dateutil.parser.ParserError, IndexError) as e:
-                msg = f"{self.template}: Failed to parse build timestamp format."
-                raise TemplateError(msg) from e
+            self.publish(db_path=db_path, repository_publish=repository_publish)
 
-            rpm = (
-                template_artifacts_dir
-                / "rpm"
-                / f"qubes-template-{self.template.name}-{TEMPLATE_VERSION}-{timestamp}.noarch.rpm"
+            info.setdefault("repository-publish", []).append(
+                {
+                    "name": repository_publish,
+                    "timestamp": datetime.utcnow().strftime("%Y%m%d%H%MZ"),
+                }
             )
-            if not rpm.exists():
-                msg = f"{self.template}: Cannot find template RPM '{rpm}'."
-                raise TemplateError(msg)
-
-            # We check that signature exists (--check-only option)
-            log.info(f"{self.template}: Verifying signatures.")
-            sign_key = self.get_sign_key()
-            try:
-                cmd = [
-                    f"{self.plugins_dir}/sign_rpm/scripts/sign-rpm "
-                    f"--sign-key {sign_key} --db-path {db_path} --rpm {rpm} --check-only"
-                ]
-                self.executor.run(cmd)
-            except ExecutorError as e:
-                msg = f"{self.template}: Failed to check signatures."
-                raise TemplateError(msg) from e
-
-            # Publish packages with hardlinks to built RPMs
-            log.info(f"{self.template}: Publishing RPMs.")
-            target_dir = artifacts_dir / f"{self.qubes_release}/{repository_publish}"
-            try:
-                target_path = target_dir / "rpm" / rpm.name
-                target_path.unlink(missing_ok=True)
-                # target_path.hardlink_to(rpm)
-                os.link(rpm, target_path)
-            except (ValueError, PermissionError, NotImplementedError) as e:
-                msg = f"{self.template}: Failed to publish packages."
-                raise TemplateError(msg) from e
-
-            # Createrepo published templates
-            log.info(f"{self.template}: Updating metadata.")
-            cmd = [f"cd {target_dir}", "createrepo_c ."]
-            try:
-                shutil.rmtree(target_dir / "repodata")
-                self.executor.run(cmd)
-            except (ExecutorError, OSError) as e:
-                msg = f"{self.template}: Failed to 'createrepo_c'"
-                raise TemplateError(msg) from e
-
-            # Sign metadata
-            log.info(f"{self.template}: Signing metadata.")
-            repomd = target_dir / "repodata/repomd.xml"
-            cmd = [
-                f"{self.gpg_client} --batch --no-tty --yes --detach-sign --armor -u {sign_key} {repomd} > {repomd}.asc",
-            ]
-            try:
-                self.executor.run(cmd)
-            except (ExecutorError, OSError) as e:
-                msg = f"{self.template}: Failed to sign metadata"
-                raise TemplateError(msg) from e
-
             # Save package information we published for committing into current
-            template_artifacts_dir.mkdir(parents=True, exist_ok=True)
-            try:
-                with open(
-                    template_artifacts_dir / f"{self.template.name}.publish.yml",
-                    "w",
-                ) as f:
-                    info = {
-                        "repository-publish": repository_publish,
-                        "timestamp": timestamp,
-                    }
-                    f.write(yaml.safe_dump(info))
-            except (PermissionError, yaml.YAMLError) as e:
-                msg = f"{self.template}: Failed to write publish info."
-                raise TemplateError(msg) from e
+            self.save_artifacts_info(stage, info)
+
+        if stage == "publish" and unpublish:
+            if not self.is_published(repository_publish):
+                log.info(f"{self.template}: Not published to '{repository_publish}'.")
+                return
+
+            publish_info = self.get_artifacts_info(stage=stage)
+            self.unpublish(
+                repository_publish=repository_publish,
+            )
+
+            # Save package information we published for committing into current. If the packages
+            # are not published into another repository, we delete the publish stage information.
+            publish_info["repository-publish"] = [
+                r
+                for r in publish_info.get("repository-publish", [])
+                if r["name"] != repository_publish
+            ]
+            if publish_info.get("repository-publish", []):
+                self.save_artifacts_info(stage="publish", info=publish_info)
+            else:
+                log.info(
+                    f"{self.template}: Not published anywhere else, deleting publish info."
+                )
+                self.delete_artifacts_info(stage="publish")

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -299,41 +299,39 @@ class TemplatePlugin(Plugin):
                 )
                 # Check template is published in testing
                 if not (
-                    template_artifacts_dir / f"{self.template.name}_publish_info.yml"
+                    template_artifacts_dir / f"{self.template.name}.publish.yml"
                 ).exists():
                     raise TemplateError(failure_msg)
-                else:
-                    # Get existing publish info
-                    with open(
-                        template_artifacts_dir
-                        / f"{self.template.name}_publish_info.yml"
-                    ) as f:
-                        publish_info = yaml.safe_load(f.read())
-                    # Check for valid repositories under which packages are published
-                    if (
-                        publish_info.get("repository-publish", None)
-                        not in TEMPLATE_REPOSITORIES
-                    ):
-                        raise TemplateError(failure_msg)
-                    if publish_info["repository-publish"] == repository_publish:
-                        log.info(
-                            f"{self.template}: Already published to '{repository_publish}'."
-                        )
-                        return
 
-                    # Check minimum day that packages are available for testing
-                    publish_date = datetime.datetime.utcfromtimestamp(
-                        os.stat(
-                            template_artifacts_dir
-                            / f"{self.template.name}_publish_info.yml"
-                        ).st_mtime
+                # Get existing publish info
+                with open(
+                    template_artifacts_dir / f"{self.template.name}.publish.yml"
+                ) as f:
+                    publish_info = yaml.safe_load(f.read())
+                # Check for valid repositories under which packages are published
+                if (
+                    publish_info.get("repository-publish", None)
+                    not in TEMPLATE_REPOSITORIES
+                ):
+                    raise TemplateError(failure_msg)
+                if publish_info["repository-publish"] == repository_publish:
+                    log.info(
+                        f"{self.template}: Already published to '{repository_publish}'."
                     )
-                    # Check that packages have been published before threshold_date
-                    threshold_date = datetime.datetime.utcnow() - datetime.timedelta(
-                        days=MIN_AGE_DAYS
-                    )
-                    if not ignore_min_age and publish_date > threshold_date:
-                        raise TemplateError(failure_msg)
+                    return
+
+                # Check minimum day that packages are available for testing
+                publish_date = datetime.datetime.utcfromtimestamp(
+                    os.stat(
+                        template_artifacts_dir / f"{self.template.name}.publish.yml"
+                    ).st_mtime
+                )
+                # Check that packages have been published before threshold_date
+                threshold_date = datetime.datetime.utcnow() - datetime.timedelta(
+                    days=MIN_AGE_DAYS
+                )
+                if not ignore_min_age and publish_date > threshold_date:
+                    raise TemplateError(failure_msg)
 
             # Ensure dbpath from sign stage (still) exists
             db_path = template_artifacts_dir / "rpmdb"
@@ -434,7 +432,7 @@ class TemplatePlugin(Plugin):
             template_artifacts_dir.mkdir(parents=True, exist_ok=True)
             try:
                 with open(
-                    template_artifacts_dir / f"{self.template.name}_publish_info.yml",
+                    template_artifacts_dir / f"{self.template.name}.publish.yml",
                     "w",
                 ) as f:
                     info = {

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -147,7 +147,11 @@ class TemplatePlugin(Plugin):
         return template_timestamp
 
     def run(
-        self, stage: str, repository_publish: str = None, ignore_min_age: bool = False
+        self,
+        stage: str,
+        repository_publish: str = None,
+        ignore_min_age: bool = False,
+        unpublish: bool = False,
     ):
 
         repository_dir = self.get_repository_dir() / self.dist.distribution

--- a/qubesbuilder/plugins/template_debian/__init__.py
+++ b/qubesbuilder/plugins/template_debian/__init__.py
@@ -70,10 +70,16 @@ class DEBTemplatePlugin(TemplatePlugin):
         )
 
     def run(
-        self, stage: str, repository_publish: str = None, ignore_min_age: bool = False
+        self,
+        stage: str,
+        repository_publish: str = None,
+        ignore_min_age: bool = False,
+        unpublish: bool = False,
+        **kwargs,
     ):
         super().run(
             stage=stage,
             repository_publish=repository_publish,
             ignore_min_age=ignore_min_age,
+            unpublish=unpublish,
         )

--- a/qubesbuilder/plugins/template_rpm/__init__.py
+++ b/qubesbuilder/plugins/template_rpm/__init__.py
@@ -68,10 +68,16 @@ class RPMTemplatePlugin(TemplatePlugin):
         self.environment.update({"TEMPLATE_CONTENT_DIR": PLUGINS_DIR / "template_rpm"})
 
     def run(
-        self, stage: str, repository_publish: str = None, ignore_min_age: bool = False
+        self,
+        stage: str,
+        repository_publish: str = None,
+        ignore_min_age: bool = False,
+        unpublish: bool = False,
+        **kwargs,
     ):
         super().run(
             stage=stage,
             repository_publish=repository_publish,
             ignore_min_age=ignore_min_age,
+            unpublish=unpublish,
         )

--- a/qubesbuilder/plugins/template_whonix/__init__.py
+++ b/qubesbuilder/plugins/template_whonix/__init__.py
@@ -77,10 +77,16 @@ class WhonixTemplatePlugin(DEBTemplatePlugin):
         )
 
     def run(
-        self, stage: str, repository_publish: str = None, ignore_min_age: bool = False
+        self,
+        stage: str,
+        repository_publish: str = None,
+        ignore_min_age: bool = False,
+        unpublish: bool = False,
+        **kwargs,
     ):
         super().run(
             stage=stage,
             repository_publish=repository_publish,
             ignore_min_age=ignore_min_age,
+            unpublish=unpublish,
         )

--- a/qubesbuilder/template.py
+++ b/qubesbuilder/template.py
@@ -45,6 +45,7 @@ class QubesTemplate:
 
         self.flavor = template_desc.get("flavor", "")
         self.options = template_desc.get("options", [])
+        self.timestamp = None
 
     def to_str(self) -> str:
         return f"{self.name}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -997,14 +997,34 @@ def test_unpublish_vm_bullseye():
 
 
 def test_prep_template_fedora_35_xfce():
-    qb_call(DEFAULT_BUILDER_CONF, "-t", "fedora-35-xfce", "template", "prep")
+    qb_call(
+        DEFAULT_BUILDER_CONF,
+        "-e",
+        "qubes",
+        "--executor-option",
+        "dispvm=qubes-builder-dvm",
+        "-t",
+        "fedora-35-xfce",
+        "template",
+        "prep",
+    )
 
     assert (ARTIFACTS_DIR / "templates/prepared_images/fedora-35-xfce.img").exists()
     assert (ARTIFACTS_DIR / "templates/build_timestamp_fedora-35-xfce").exists()
 
 
 def test_build_template_fedora_35_xfce():
-    qb_call(DEFAULT_BUILDER_CONF, "-t", "fedora-35-xfce", "template", "build")
+    qb_call(
+        DEFAULT_BUILDER_CONF,
+        "-e",
+        "qubes",
+        "--executor-option",
+        "dispvm=qubes-builder-dvm",
+        "-t",
+        "fedora-35-xfce",
+        "template",
+        "build",
+    )
     assert (ARTIFACTS_DIR / "templates/prepared_images/fedora-35-xfce.img").exists()
     assert (
         ARTIFACTS_DIR / "templates/qubeized_images/fedora-35-xfce/root.img"
@@ -1127,7 +1147,7 @@ def test_publish_template_fedora_35_xfce():
         assert info.get("timestamp", []) == template_timestamp
         assert set([r["name"] for r in info.get("repository-publish", [])]) == {
             "templates-itl-testing",
-            "templates-itl"
+            "templates-itl",
         }
 
     # Check that packages are in the published repository

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,1140 @@
+import os.path
+import shutil
+import subprocess
+import tempfile
+import dnf
+import yaml
+import dateutil.parser
+from dateutil.parser import parse as parsedate
+from datetime import datetime, timedelta
+from qubesbuilder.common import PROJECT_PATH
+
+DEFAULT_BUILDER_CONF = PROJECT_PATH / "tests/builder-ci.yml"
+ARTIFACTS_DIR = PROJECT_PATH / "artifacts"
+
+
+def qb_call(builder_conf, *args, **kwargs):
+    subprocess.check_call(
+        [PROJECT_PATH / "qb", "--verbose", "--builder-conf", builder_conf, *args],
+        **kwargs,
+    )
+
+
+def qb_call_output(builder_conf, *args, **kwargs):
+    return subprocess.check_output(
+        [PROJECT_PATH / "qb", "--verbose", "--builder-conf", builder_conf, *args],
+        **kwargs,
+    )
+
+
+def deb_packages_list(repository_dir, suite, **kwargs):
+    return (
+        subprocess.check_output(
+            ["reprepro", "-b", repository_dir, "list", suite],
+            **kwargs,
+        )
+        .decode()
+        .splitlines()
+    )
+
+
+def rpm_packages_list(repository_dir):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = dnf.Base()
+        base.conf.installroot = tmpdir
+        base.conf.cachedir = tmpdir + "/cache"
+        base.repos.add_new_repo(
+            repoid="local", conf=base.conf, baseurl=[repository_dir]
+        )
+        base.fill_sack()
+        q = base.sack.query()
+        return [str(p) + ".rpm" for p in q.available()]
+
+
+#
+# Fetch
+#
+
+
+def test_fetch():
+    qb_call(DEFAULT_BUILDER_CONF, "package", "fetch")
+
+    assert (ARTIFACTS_DIR / "distfiles/qasync-0.9.4.tar.gz").exists()
+    assert (ARTIFACTS_DIR / "distfiles/xfwm4-4.14.2.tar.bz2").exists()
+
+    for component in [
+        "core-qrexec",
+        "core-vchan-xen",
+        "desktop-linux-xfce4-xfwm4",
+        "python-qasync",
+    ]:
+        assert (ARTIFACTS_DIR / "sources" / component / ".qubesbuilder").exists()
+
+
+def test_fetch_skip():
+    result = qb_call_output(
+        DEFAULT_BUILDER_CONF, "package", "fetch", stderr=subprocess.STDOUT
+    ).decode()
+    for sentence in [
+        "python-qasync: source already fetched. Skipping.",
+        "core-vchan-xen: source already fetched. Skipping.",
+        "core-qrexec: source already fetched. Skipping.",
+        "desktop-linux-xfce4-xfwm4: source already fetched. Skipping.",
+        "python-qasync: file qasync-0.9.4.tar.gz already downloaded. Skipping.",
+        "desktop-linux-xfce4-xfwm4: file xfwm4-4.14.2.tar.bz2 already downloaded. Skipping.",
+    ]:
+        assert sentence in result
+
+
+#
+# Pipeline for core-qrexec and host-fc32
+#
+
+
+def test_prep_host_fc32():
+    qb_call(
+        DEFAULT_BUILDER_CONF, "-c", "core-qrexec", "-d", "host-fc32", "package", "prep"
+    )
+
+    with open(
+        ARTIFACTS_DIR
+        / "components/core-qrexec/4.1.16-1/host-fc32/prep/qubes-qrexec.prep.yml"
+    ) as f:
+        info = yaml.safe_load(f.read())
+
+    rpms = [
+        "qubes-core-qrexec-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.1.16-1.fc32.x86_64.rpm",
+    ]
+    source_hash = "c9b621ee1529dd47fa648f9e555eef1b4d9ce41f"
+    srpm = "qubes-core-qrexec-4.1.16-1.fc32.src.rpm"
+
+    assert info.get("rpms", []) == rpms
+    assert info.get("source-hash", None) == source_hash
+    assert info.get("srpm", []) == srpm
+
+    with open(
+        ARTIFACTS_DIR
+        / "components/core-qrexec/4.1.16-1/host-fc32/prep/qubes-qrexec-dom0.prep.yml"
+    ) as f:
+        info = yaml.safe_load(f.read())
+
+    rpms = [
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.1.16-1.fc32.x86_64.rpm",
+    ]
+    srpm = "qubes-core-qrexec-dom0-4.1.16-1.fc32.src.rpm"
+
+    assert info.get("rpms", []) == rpms
+    assert info.get("source-hash", None) == source_hash
+    assert info.get("srpm", []) == srpm
+
+
+def test_build_host_fc32():
+    qb_call(
+        DEFAULT_BUILDER_CONF, "-c", "core-qrexec", "-d", "host-fc32", "package", "build"
+    )
+
+    with open(
+        ARTIFACTS_DIR
+        / "components/core-qrexec/4.1.16-1/host-fc32/build/qubes-qrexec.build.yml"
+    ) as f:
+        info = yaml.safe_load(f.read())
+
+    rpms = [
+        "qubes-core-qrexec-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.1.16-1.fc32.x86_64.rpm",
+    ]
+    source_hash = "c9b621ee1529dd47fa648f9e555eef1b4d9ce41f"
+    srpm = "qubes-core-qrexec-4.1.16-1.fc32.src.rpm"
+
+    assert info.get("rpms", []) == rpms
+    assert info.get("source-hash", None) == source_hash
+    assert info.get("srpm", []) == srpm
+
+    with open(
+        ARTIFACTS_DIR
+        / "components/core-qrexec/4.1.16-1/host-fc32/build/qubes-qrexec-dom0.build.yml"
+    ) as f:
+        info = yaml.safe_load(f.read())
+
+    rpms = [
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.1.16-1.fc32.x86_64.rpm",
+    ]
+    srpm = "qubes-core-qrexec-dom0-4.1.16-1.fc32.src.rpm"
+
+    assert info.get("rpms", []) == rpms
+    assert info.get("source-hash", None) == source_hash
+    assert info.get("srpm", []) == srpm
+
+
+def test_sign_host_fc32():
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        # Better copy testing keyring into a separate directory to prevent locks inside
+        # local sources (when executed locally).
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+        # Enforce keyring location
+        env["GNUPGHOME"] = gnupghome
+        # We prevent rpm to find ~/.rpmmacros
+        env["HOME"] = tmpdir
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "core-qrexec",
+            "-d",
+            "host-fc32",
+            "package",
+            "sign",
+            env=env,
+        )
+
+    assert (
+        ARTIFACTS_DIR
+        / "components/core-qrexec/4.1.16-1/host-fc32/sign/632F8C69E01B25C9E0C3ADF2F360C0D259FB650C.asc"
+    ).exists()
+
+    dbpath = ARTIFACTS_DIR / "components/core-qrexec/4.1.16-1/host-fc32/sign/rpmdb"
+    assert dbpath.exists()
+
+    rpms = [
+        "qubes-core-qrexec-4.1.16-1.fc32.src.rpm",
+        "qubes-core-qrexec-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.src.rpm",
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.1.16-1.fc32.x86_64.rpm",
+    ]
+    for rpm in rpms:
+        rpm_path = (
+            ARTIFACTS_DIR
+            / f"components/core-qrexec/4.1.16-1/host-fc32/{f'prep/{rpm}' if rpm.endswith('.src.rpm') else f'build/rpm/{rpm}'}"
+        )
+        assert rpm_path.exists()
+        result = subprocess.run(
+            f"rpm --dbpath {dbpath} -K {rpm_path}",
+            check=True,
+            capture_output=True,
+            shell=True,
+        )
+        assert "digests signatures OK" in result.stdout.decode()
+
+
+def test_publish_host_fc32():
+    source_hash = "c9b621ee1529dd47fa648f9e555eef1b4d9ce41f"
+
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        # publish into unstable
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "core-qrexec",
+            "-d",
+            "host-fc32",
+            "repository",
+            "publish",
+            "unstable",
+            env=env,
+        )
+
+        rpms = [
+            "qubes-core-qrexec-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-debugsource-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-libs-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-libs-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-devel-4.1.16-1.fc32.x86_64.rpm",
+        ]
+        srpm = "qubes-core-qrexec-4.1.16-1.fc32.src.rpm"
+
+        rpms_dom0 = [
+            "qubes-core-qrexec-dom0-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        ]
+        srpm_dom0 = "qubes-core-qrexec-dom0-4.1.16-1.fc32.src.rpm"
+
+        with open(
+            ARTIFACTS_DIR
+            / "components/core-qrexec/4.1.16-1/host-fc32/publish/qubes-qrexec.publish.yml"
+        ) as f:
+            info = yaml.safe_load(f.read())
+
+        with open(
+            ARTIFACTS_DIR
+            / "components/core-qrexec/4.1.16-1/host-fc32/publish/qubes-qrexec-dom0.publish.yml"
+        ) as f:
+            info_dom0 = yaml.safe_load(f.read())
+
+        assert info.get("rpms", []) == rpms
+        assert info.get("srpm", []) == srpm
+        assert info.get("source-hash", None) == source_hash
+        assert ["unstable"] == [r["name"] for r in info.get("repository-publish", [])]
+
+        assert info_dom0.get("rpms", []) == rpms_dom0
+        assert info_dom0.get("srpm", []) == srpm_dom0
+        assert info_dom0.get("source-hash", None) == source_hash
+        assert ["unstable"] == [r["name"] for r in info.get("repository-publish", [])]
+
+        # publish into current-testing
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "core-qrexec",
+            "-d",
+            "host-fc32",
+            "repository",
+            "publish",
+            "current-testing",
+            env=env,
+        )
+        with open(
+            ARTIFACTS_DIR
+            / "components/core-qrexec/4.1.16-1/host-fc32/publish/qubes-qrexec.publish.yml"
+        ) as f:
+            info = yaml.safe_load(f.read())
+
+        with open(
+            ARTIFACTS_DIR
+            / "components/core-qrexec/4.1.16-1/host-fc32/publish/qubes-qrexec-dom0.publish.yml"
+        ) as f:
+            info_dom0 = yaml.safe_load(f.read())
+
+        assert info.get("rpms", []) == rpms
+        assert info.get("srpm", []) == srpm
+        assert info.get("source-hash", None) == source_hash
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+        }
+
+        assert info_dom0.get("rpms", []) == rpms_dom0
+        assert info_dom0.get("srpm", []) == srpm_dom0
+        assert info_dom0.get("source-hash", None) == source_hash
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+        }
+
+        # publish into current
+        fake_time = (datetime.utcnow() - timedelta(days=7)).strftime("%Y%m%d%H%MZ")
+        publish_file = (
+            ARTIFACTS_DIR
+            / "components/core-qrexec/4.1.16-1/host-fc32/publish/qubes-qrexec.publish.yml"
+        )
+        publish_dom0_file = (
+            ARTIFACTS_DIR
+            / "components/core-qrexec/4.1.16-1/host-fc32/publish/qubes-qrexec-dom0.publish.yml"
+        )
+
+        for r in info["repository-publish"]:
+            if r["name"] == "current-testing":
+                r["timestamp"] = fake_time
+                break
+
+        for r in info_dom0["repository-publish"]:
+            if r["name"] == "current-testing":
+                r["timestamp"] = fake_time
+                break
+
+        with open(publish_file, "w") as f:
+            f.write(yaml.safe_dump(info))
+
+        with open(publish_dom0_file, "w") as f:
+            f.write(yaml.safe_dump(info_dom0))
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "core-qrexec",
+            "-d",
+            "host-fc32",
+            "repository",
+            "publish",
+            "current",
+            env=env,
+        )
+        with open(publish_file) as f:
+            info = yaml.safe_load(f.read())
+
+        with open(publish_dom0_file) as f:
+            info_dom0 = yaml.safe_load(f.read())
+
+        assert info.get("rpms", []) == rpms
+        assert info.get("srpm", []) == srpm
+        assert info.get("source-hash", None) == source_hash
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+            "current",
+        }
+
+        assert info_dom0.get("rpms", []) == rpms_dom0
+        assert info_dom0.get("srpm", []) == srpm_dom0
+        assert info_dom0.get("source-hash", None) == source_hash
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+            "current",
+        }
+
+    rpms = [
+        "qubes-core-qrexec-4.1.16-1.fc32.src.rpm",
+        "qubes-core-qrexec-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.src.rpm",
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.1.16-1.fc32.x86_64.rpm",
+    ]
+
+    # Check that packages are in the published repository
+    for repository in ["unstable", "current-testing", "current"]:
+        repository_dir = (
+            f"file://{ARTIFACTS_DIR}/repository-publish/rpm/r4.2/{repository}/host/fc32"
+        )
+        packages = rpm_packages_list(repository_dir)
+        assert set(rpms) == set(packages)
+
+
+# Check that we properly ignore already done stages.
+
+
+def test_prep_host_fc32_skip():
+    result = qb_call_output(
+        DEFAULT_BUILDER_CONF,
+        "-c",
+        "core-qrexec",
+        "-d",
+        "host-fc32",
+        "package",
+        "prep",
+        stderr=subprocess.STDOUT,
+    ).decode()
+    print(result)
+    assert (
+        "core-qrexec:host-fedora-32.x86_64: Source hash is the same than already prepared source. Skipping."
+        in result
+    )
+
+
+def test_build_host_fc32_skip():
+    result = qb_call_output(
+        DEFAULT_BUILDER_CONF,
+        "-c",
+        "core-qrexec",
+        "-d",
+        "host-fc32",
+        "package",
+        "build",
+        stderr=subprocess.STDOUT,
+    ).decode()
+    print(result)
+    assert (
+        "core-qrexec:host-fedora-32.x86_64: Source hash is the same than already built source. Skipping."
+        in result
+    )
+
+
+def test_sign_host_fc32_skip():
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        result = qb_call_output(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "core-qrexec",
+            "-d",
+            "host-fc32",
+            "package",
+            "sign",
+            stderr=subprocess.STDOUT,
+            env=env,
+        ).decode()
+
+    rpms = [
+        "qubes-core-qrexec-4.1.16-1.fc32.src.rpm",
+        "qubes-core-qrexec-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.src.rpm",
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.1.16-1.fc32.x86_64.rpm",
+    ]
+    for rpm in rpms:
+        assert f"{rpm} has already a valid signature. Skipping." in result
+
+
+# Check that we unpublish properly from current-testing
+
+
+def test_unpublish_host_fc32():
+    source_hash = "c9b621ee1529dd47fa648f9e555eef1b4d9ce41f"
+
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        # publish into unstable
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "core-qrexec",
+            "-d",
+            "host-fc32",
+            "repository",
+            "unpublish",
+            "current",
+            env=env,
+        )
+
+        rpms = [
+            "qubes-core-qrexec-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-debugsource-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-libs-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-libs-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-devel-4.1.16-1.fc32.x86_64.rpm",
+        ]
+        srpm = "qubes-core-qrexec-4.1.16-1.fc32.src.rpm"
+
+        rpms_dom0 = [
+            "qubes-core-qrexec-dom0-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        ]
+        srpm_dom0 = "qubes-core-qrexec-dom0-4.1.16-1.fc32.src.rpm"
+
+        with open(
+            ARTIFACTS_DIR
+            / "components/core-qrexec/4.1.16-1/host-fc32/publish/qubes-qrexec.publish.yml"
+        ) as f:
+            info = yaml.safe_load(f.read())
+
+        with open(
+            ARTIFACTS_DIR
+            / "components/core-qrexec/4.1.16-1/host-fc32/publish/qubes-qrexec-dom0.publish.yml"
+        ) as f:
+            info_dom0 = yaml.safe_load(f.read())
+
+        assert info.get("rpms", []) == rpms
+        assert info.get("srpm", []) == srpm
+        assert info.get("source-hash", None) == source_hash
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+        }
+
+        assert info_dom0.get("rpms", []) == rpms_dom0
+        assert info_dom0.get("srpm", []) == srpm_dom0
+        assert info_dom0.get("source-hash", None) == source_hash
+        assert set([r["name"] for r in info_dom0.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+        }
+
+    # Check that packages are in the published repository
+    rpms = [
+        "qubes-core-qrexec-4.1.16-1.fc32.src.rpm",
+        "qubes-core-qrexec-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.src.rpm",
+        "qubes-core-qrexec-dom0-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.1.16-1.fc32.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.1.16-1.fc32.x86_64.rpm",
+    ]
+    for repository in ["unstable", "current-testing", "current"]:
+        repository_dir = (
+            f"file://{ARTIFACTS_DIR}/repository-publish/rpm/r4.2/{repository}/host/fc32"
+        )
+        packages = rpm_packages_list(repository_dir)
+        if repository == "current":
+            assert packages == []
+        else:
+            assert set(rpms) == set(packages)
+
+
+#
+# Pipeline for python-qasync and vm-bullseye
+#
+
+
+def test_prep_vm_bullseye():
+    qb_call(
+        DEFAULT_BUILDER_CONF,
+        "-c",
+        "python-qasync",
+        "-d",
+        "vm-bullseye",
+        "package",
+        "prep",
+    )
+
+    with open(
+        ARTIFACTS_DIR
+        / "components/python-qasync/0.9.4-2/vm-bullseye/prep/debian.prep.yml"
+    ) as f:
+        info = yaml.safe_load(f.read())
+
+    source_hash = "0f90aeea99f2a1309078846b0c3fd83dc73fa0a9"
+    packages = [
+        "python3-qasync_0.9.4-2+deb11u1_all.deb",
+        "python3-qasync-dbgsym_0.9.4-2+deb11u1_all.deb",
+    ]
+    debian = "python-qasync_0.9.4-2+deb11u1.debian.tar.xz"
+    dsc = "python-qasync_0.9.4-2+deb11u1.dsc"
+    orig = "python-qasync_0.9.4.orig.tar.gz"
+    package_release_name = "python-qasync_0.9.4"
+    package_release_name_full = "python-qasync_0.9.4-2+deb11u1"
+
+    assert info.get("packages", []) == packages
+    assert info.get("source-hash", None) == source_hash
+    assert info.get("debian", None) == debian
+    assert info.get("dsc", None) == dsc
+    assert info.get("orig", None) == orig
+    assert info.get("package-release-name", None) == package_release_name
+    assert info.get("package-release-name-full", None) == package_release_name_full
+
+
+def test_build_vm_bullseye():
+    qb_call(
+        DEFAULT_BUILDER_CONF,
+        "-c",
+        "python-qasync",
+        "-d",
+        "vm-bullseye",
+        "package",
+        "build",
+    )
+
+    with open(
+        ARTIFACTS_DIR
+        / "components/python-qasync/0.9.4-2/vm-bullseye/build/debian.build.yml"
+    ) as f:
+        info = yaml.safe_load(f.read())
+
+    source_hash = "0f90aeea99f2a1309078846b0c3fd83dc73fa0a9"
+    packages = ["python3-qasync_0.9.4-2+deb11u1_all.deb"]
+    debian = "python-qasync_0.9.4-2+deb11u1.debian.tar.xz"
+    dsc = "python-qasync_0.9.4-2+deb11u1.dsc"
+    orig = "python-qasync_0.9.4.orig.tar.gz"
+    package_release_name = "python-qasync_0.9.4"
+    package_release_name_full = "python-qasync_0.9.4-2+deb11u1"
+
+    assert info.get("packages", []) == packages
+    assert info.get("source-hash", None) == source_hash
+    assert info.get("debian", None) == debian
+    assert info.get("dsc", None) == dsc
+    assert info.get("orig", None) == orig
+    assert info.get("package-release-name", None) == package_release_name
+    assert info.get("package-release-name-full", None) == package_release_name_full
+
+
+def test_sign_vm_bullseye():
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "python-qasync",
+            "-d",
+            "vm-bullseye",
+            "package",
+            "sign",
+            env=env,
+        )
+
+    assert (
+        ARTIFACTS_DIR
+        / "components/python-qasync/0.9.4-2/vm-bullseye/sign/632F8C69E01B25C9E0C3ADF2F360C0D259FB650C.asc"
+    ).exists()
+
+    keyring_dir = (
+        ARTIFACTS_DIR / "components/python-qasync/0.9.4-2/vm-bullseye/sign/keyring"
+    )
+    assert keyring_dir.exists()
+
+    files = [
+        "python-qasync_0.9.4-2+deb11u1.dsc",
+        "python-qasync_0.9.4-2+deb11u1_amd64.changes",
+        "python-qasync_0.9.4-2+deb11u1_amd64.buildinfo",
+    ]
+    for f in files:
+        file_path = (
+            ARTIFACTS_DIR / f"components/python-qasync/0.9.4-2/vm-bullseye/build/{f}"
+        )
+        assert file_path.exists()
+        result = subprocess.run(
+            f"gpg2 --homedir {keyring_dir} --verify {file_path}",
+            shell=True,
+        )
+        assert result.returncode == 0
+
+
+def test_publish_vm_bullseye():
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        # publish into unstable
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "python-qasync",
+            "-d",
+            "vm-bullseye",
+            "repository",
+            "publish",
+            "unstable",
+            env=env,
+        )
+
+        with open(
+            ARTIFACTS_DIR
+            / "components/python-qasync/0.9.4-2/vm-bullseye/publish/debian.publish.yml"
+        ) as f:
+            info = yaml.safe_load(f.read())
+
+        source_hash = "0f90aeea99f2a1309078846b0c3fd83dc73fa0a9"
+        packages = ["python3-qasync_0.9.4-2+deb11u1_all.deb"]
+        debian = "python-qasync_0.9.4-2+deb11u1.debian.tar.xz"
+        dsc = "python-qasync_0.9.4-2+deb11u1.dsc"
+        orig = "python-qasync_0.9.4.orig.tar.gz"
+        package_release_name = "python-qasync_0.9.4"
+        package_release_name_full = "python-qasync_0.9.4-2+deb11u1"
+
+        assert info.get("packages", []) == packages
+        assert info.get("source-hash", None) == source_hash
+        assert info.get("debian", None) == debian
+        assert info.get("dsc", None) == dsc
+        assert info.get("orig", None) == orig
+        assert info.get("package-release-name", None) == package_release_name
+        assert info.get("package-release-name-full", None) == package_release_name_full
+        assert ["unstable"] == [r["name"] for r in info.get("repository-publish", [])]
+
+        # publish into current-testing
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "python-qasync",
+            "-d",
+            "vm-bullseye",
+            "repository",
+            "publish",
+            "current-testing",
+            env=env,
+        )
+        with open(
+            ARTIFACTS_DIR
+            / "components/python-qasync/0.9.4-2/vm-bullseye/publish/debian.publish.yml"
+        ) as f:
+            info = yaml.safe_load(f.read())
+
+        assert info.get("packages", []) == packages
+        assert info.get("source-hash", None) == source_hash
+        assert info.get("debian", None) == debian
+        assert info.get("dsc", None) == dsc
+        assert info.get("orig", None) == orig
+        assert info.get("package-release-name", None) == package_release_name
+        assert info.get("package-release-name-full", None) == package_release_name_full
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+        }
+
+        # publish into current
+        fake_time = (datetime.utcnow() - timedelta(days=7)).strftime("%Y%m%d%H%MZ")
+        publish_file = (
+            ARTIFACTS_DIR
+            / "components/python-qasync/0.9.4-2/vm-bullseye/publish/debian.publish.yml"
+        )
+
+        for r in info["repository-publish"]:
+            if r["name"] == "current-testing":
+                r["timestamp"] = fake_time
+                break
+
+        with open(publish_file, "w") as f:
+            f.write(yaml.safe_dump(info))
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "python-qasync",
+            "-d",
+            "vm-bullseye",
+            "repository",
+            "publish",
+            "current",
+            env=env,
+        )
+        with open(publish_file) as f:
+            info = yaml.safe_load(f.read())
+
+        assert info.get("packages", []) == packages
+        assert info.get("source-hash", None) == source_hash
+        assert info.get("debian", None) == debian
+        assert info.get("dsc", None) == dsc
+        assert info.get("orig", None) == orig
+        assert info.get("package-release-name", None) == package_release_name
+        assert info.get("package-release-name-full", None) == package_release_name_full
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+            "current",
+        }
+
+    # Check that packages are in the published repositories
+    repository_dir = ARTIFACTS_DIR / "repository-publish/deb/r4.2/vm"
+    for codename in ["bullseye-unstable", "bullseye-testing", "bullseye"]:
+        packages = deb_packages_list(repository_dir, codename)
+        expected_packages = [
+            f"{codename}|main|amd64: python3-qasync 0.9.4-2+deb11u1",
+            f"{codename}|main|source: python-qasync 0.9.4-2+deb11u1",
+        ]
+        assert set(packages) == set(expected_packages)
+
+
+# Check that we properly ignore already done stages.
+
+
+def test_prep_vm_bullseye_skip():
+    result = qb_call_output(
+        DEFAULT_BUILDER_CONF,
+        "-c",
+        "python-qasync",
+        "-d",
+        "vm-bullseye",
+        "package",
+        "prep",
+        stderr=subprocess.STDOUT,
+    ).decode()
+    print(result)
+    assert (
+        "python-qasync:vm-debian-11.amd64: Source hash is the same than already prepared source. Skipping."
+        in result
+    )
+
+
+def test_build_vm_bullseye_skip():
+    result = qb_call_output(
+        DEFAULT_BUILDER_CONF,
+        "-c",
+        "python-qasync",
+        "-d",
+        "vm-bullseye",
+        "package",
+        "build",
+        stderr=subprocess.STDOUT,
+    ).decode()
+    print(result)
+    assert (
+        "python-qasync:vm-debian-11.amd64: Source hash is the same than already built source. Skipping."
+        in result
+    )
+
+
+def test_sign_vm_bullseye_skip():
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        result = qb_call_output(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "python-qasync",
+            "-d",
+            "vm-bullseye",
+            "package",
+            "sign",
+            stderr=subprocess.STDOUT,
+            env=env,
+        ).decode()
+
+    assert f"Leaving current signature unchanged." in result
+
+
+# Check that we unpublish properly from current-testing
+
+
+def test_unpublish_vm_bullseye():
+    # FIXME: we rely on previous test_publish_vm_bullseye being ran before
+    repository_dir = ARTIFACTS_DIR / "repository-publish/deb/r4.2/vm"
+    for codename in ["bullseye-unstable", "bullseye-testing", "bullseye"]:
+        packages = deb_packages_list(repository_dir, codename)
+        expected_packages = [
+            f"{codename}|main|amd64: python3-qasync 0.9.4-2+deb11u1",
+            f"{codename}|main|source: python-qasync 0.9.4-2+deb11u1",
+        ]
+        assert set(packages) == set(expected_packages)
+
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        # publish into unstable
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-c",
+            "python-qasync",
+            "-d",
+            "vm-bullseye",
+            "repository",
+            "unpublish",
+            "current",
+            env=env,
+        )
+
+        source_hash = "0f90aeea99f2a1309078846b0c3fd83dc73fa0a9"
+        packages = ["python3-qasync_0.9.4-2+deb11u1_all.deb"]
+        debian = "python-qasync_0.9.4-2+deb11u1.debian.tar.xz"
+        dsc = "python-qasync_0.9.4-2+deb11u1.dsc"
+        orig = "python-qasync_0.9.4.orig.tar.gz"
+        package_release_name = "python-qasync_0.9.4"
+        package_release_name_full = "python-qasync_0.9.4-2+deb11u1"
+
+        with open(
+            ARTIFACTS_DIR
+            / "components/python-qasync/0.9.4-2/vm-bullseye/publish/debian.publish.yml"
+        ) as f:
+            info = yaml.safe_load(f.read())
+
+        assert info.get("packages", []) == packages
+        assert info.get("source-hash", None) == source_hash
+        assert info.get("debian", None) == debian
+        assert info.get("dsc", None) == dsc
+        assert info.get("orig", None) == orig
+        assert info.get("package-release-name", None) == package_release_name
+        assert info.get("package-release-name-full", None) == package_release_name_full
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "unstable",
+            "current-testing",
+        }
+
+    # Check that packages are in the published repositories
+    repository_dir = ARTIFACTS_DIR / "repository-publish/deb/r4.2/vm"
+    for codename in ["bullseye-unstable", "bullseye-testing", "bullseye"]:
+        packages = deb_packages_list(repository_dir, codename)
+        if codename == "bullseye":
+            expected_packages = []
+        else:
+            expected_packages = [
+                f"{codename}|main|amd64: python3-qasync 0.9.4-2+deb11u1",
+                f"{codename}|main|source: python-qasync 0.9.4-2+deb11u1",
+            ]
+        assert set(packages) == set(expected_packages)
+
+
+#
+# Pipeline for Fedora 35 XFCE template
+#
+
+
+def test_prep_template_fedora_35_xfce():
+    qb_call(DEFAULT_BUILDER_CONF, "-t", "fedora-35-xfce", "template", "prep")
+
+    assert (ARTIFACTS_DIR / "templates/prepared_images/fedora-35-xfce.img").exists()
+    assert (ARTIFACTS_DIR / "templates/build_timestamp_fedora-35-xfce").exists()
+
+
+def test_build_template_fedora_35_xfce():
+    qb_call(DEFAULT_BUILDER_CONF, "-t", "fedora-35-xfce", "template", "build")
+    assert (ARTIFACTS_DIR / "templates/prepared_images/fedora-35-xfce.img").exists()
+    assert (
+        ARTIFACTS_DIR / "templates/qubeized_images/fedora-35-xfce/root.img"
+    ).exists()
+    assert (ARTIFACTS_DIR / "templates/build_timestamp_fedora-35-xfce").exists()
+
+    with open(ARTIFACTS_DIR / "templates/build_timestamp_fedora-35-xfce") as f:
+        data = f.read().splitlines()
+    template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%MZ")
+    rpm_path = (
+        ARTIFACTS_DIR
+        / f"templates/rpm/qubes-template-fedora-35-xfce-4.1.0-{template_timestamp}.noarch.rpm"
+    )
+    assert rpm_path.exists()
+
+
+def test_sign_template_fedora_35_xfce():
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        # Better copy testing keyring into a separate directory to prevent locks inside
+        # local sources (when executed locally).
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+        # Enforce keyring location
+        env["GNUPGHOME"] = gnupghome
+        # We prevent rpm to find ~/.rpmmacros
+        env["HOME"] = tmpdir
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-t",
+            "fedora-35-xfce",
+            "template",
+            "sign",
+            env=env,
+        )
+
+    assert (
+        ARTIFACTS_DIR / "templates/632F8C69E01B25C9E0C3ADF2F360C0D259FB650C.asc"
+    ).exists()
+
+    dbpath = ARTIFACTS_DIR / "templates/rpmdb"
+    assert dbpath.exists()
+
+    with open(ARTIFACTS_DIR / "templates/build_timestamp_fedora-35-xfce") as f:
+        data = f.read().splitlines()
+    template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%MZ")
+    rpm_path = (
+        ARTIFACTS_DIR
+        / f"templates/rpm/qubes-template-fedora-35-xfce-4.1.0-{template_timestamp}.noarch.rpm"
+    )
+    assert rpm_path.exists()
+    result = subprocess.run(
+        f"rpm --dbpath {dbpath} -K {rpm_path}",
+        check=True,
+        capture_output=True,
+        shell=True,
+    )
+    assert "digests signatures OK" in result.stdout.decode()
+
+
+def test_publish_template_fedora_35_xfce():
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/.gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        # publish into templates-itl-testing
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-t",
+            "fedora-35-xfce",
+            "repository",
+            "publish",
+            "templates-itl-testing",
+            env=env,
+        )
+
+        with open(ARTIFACTS_DIR / "templates/fedora-35-xfce.publish.yml") as f:
+            info = yaml.safe_load(f.read())
+
+        with open(ARTIFACTS_DIR / "templates/build_timestamp_fedora-35-xfce") as f:
+            data = f.read().splitlines()
+        template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%MZ")
+
+        assert info.get("timestamp", []) == template_timestamp
+        assert ["templates-itl-testing"] == [
+            r["name"] for r in info.get("repository-publish", [])
+        ]
+
+        # publish into templates-itl
+        fake_time = (datetime.utcnow() - timedelta(days=7)).strftime("%Y%m%d%H%MZ")
+        publish_file = ARTIFACTS_DIR / "templates/fedora-35-xfce.publish.yml"
+
+        for r in info["repository-publish"]:
+            if r["name"] == "templates-itl-testing":
+                r["timestamp"] = fake_time
+                break
+
+        with open(publish_file, "w") as f:
+            f.write(yaml.safe_dump(info))
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            "-t",
+            "fedora-35-xfce",
+            "repository",
+            "publish",
+            "templates-itl",
+            env=env,
+        )
+        with open(publish_file) as f:
+            info = yaml.safe_load(f.read())
+
+        assert info.get("timestamp", []) == template_timestamp
+        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
+            "templates-itl-testing",
+            "templates-itl"
+        }
+
+    # Check that packages are in the published repository
+    for repository in ["templates-itl-testing", "templates-itl"]:
+        rpm = f"qubes-template-fedora-35-xfce-4.1.0-{template_timestamp}.noarch.rpm"
+        repository_dir = (
+            f"file://{ARTIFACTS_DIR}/repository-publish/rpm/r4.2/{repository}"
+        )
+        packages = rpm_packages_list(repository_dir)
+        assert {rpm} == set(packages)


### PR DESCRIPTION
Several improvements features:
- Rework publish plugins
- Add unpublish mechanisms
- Skip already done stages based on source computed hash
- Ensure `isolation=nspaw` for mock when using Qubes executor