### PR TITLE
Check that branch is ancestor of remote ref

### DIFF
--- a/qubesbuilder/plugins/source/scripts/get-and-verify-source
+++ b/qubesbuilder/plugins/source/scripts/get-and-verify-source
@@ -392,6 +392,7 @@ if [ "$CURRENT_BRANCH" != "$BRANCH" ] || "$fresh_clone"; then
     fi
     if [ -n "$(git name-rev --name-only "$BRANCH" 2>/dev/null)" ]; then
         echo "--> Switching branch from $CURRENT_BRANCH branch to ${green}$BRANCH${normal}"
+        git merge-base --is-ancestor -- "$BRANCH" "$VERIFY_REF" || exit 1
         git checkout -B "$BRANCH" "$VERIFY_REF" || exit 1
     else
         echo -e "--> Switching branch from $CURRENT_BRANCH branch to new ${red}$BRANCH${normal}"

--- a/qubesbuilder/plugins/source/scripts/get-and-verify-source
+++ b/qubesbuilder/plugins/source/scripts/get-and-verify-source
@@ -407,8 +407,8 @@ fi
 
 if ! "$fresh_clone"; then
     if [ "$DO_MERGE" = "1" ]; then
-        echo "Merging FETCH_HEAD into $REPO"; \
-		git -c merge.verifySignatures=false merge $GIT_MERGE_OPTS --no-edit "$VERIFY_REF"
+        echo "Merging FETCH_HEAD into $REPO"
+        git -c merge.verifySignatures=false merge $GIT_MERGE_OPTS --no-edit "$VERIFY_REF"
     else
         echo "--> Merging..."
         git -c merge.verifySignatures=no merge $GIT_MERGE_OPTS --commit -q "$VERIFY_REF"


### PR DESCRIPTION
When switching branches, it is necessary to ensure that the call to
`git checkout -B` will perform a fast-forward update.  Use
`git merge-base --is-ancestor` to perform this check.