### PR TITLE
Template build patches

### DIFF
--- a/qubesbuilder/plugins/build_rpm/__init__.py
+++ b/qubesbuilder/plugins/build_rpm/__init__.py
@@ -116,12 +116,19 @@ class RPMBuildPlugin(BuildPlugin):
             {
                 "DIST": self.dist.name,
                 "PACKAGE_SET": self.dist.package_set.replace("host", "dom0"),
-                "USE_QUBES_REPO_VERSION": str(self.use_qubes_repo.get("version", None)),
-                "USE_QUBES_REPO_TESTING": "1"
-                if self.use_qubes_repo.get("testing", None)
-                else 0,
             }
         )
+        if self.use_qubes_repo:
+            self.environment.update(
+                {
+                    "USE_QUBES_REPO_VERSION": str(
+                        self.use_qubes_repo.get("version", None)
+                    ),
+                    "USE_QUBES_REPO_TESTING": "1"
+                    if self.use_qubes_repo.get("testing", None)
+                    else 0,
+                }
+            )
 
     def run(self, stage: str):
         """

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -109,6 +109,8 @@ class TemplatePlugin(Plugin):
                 "ARTIFACTS_DIR": BUILD_DIR,
                 "PLUGINS_DIR": PLUGINS_DIR,
                 "PACKAGES_DIR": REPOSITORY_DIR,
+                "DISCARD_PREPARED_IMAGE": "1",
+                "BUILDER_TURBO_MODE": "1",
                 "CACHE_DIR": CACHE_DIR / f"cache_{self.dist.name}",
             }
         )

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -110,12 +110,19 @@ class TemplatePlugin(Plugin):
                 "PLUGINS_DIR": PLUGINS_DIR,
                 "PACKAGES_DIR": REPOSITORY_DIR,
                 "CACHE_DIR": CACHE_DIR / f"cache_{self.dist.name}",
-                "USE_QUBES_REPO_VERSION": self.use_qubes_repo.get("version", None),
-                "USE_QUBES_REPO_TESTING": 1
-                if self.use_qubes_repo.get("testing", None)
-                else 0,
             }
         )
+        if self.use_qubes_repo:
+            self.environment.update(
+                {
+                    "USE_QUBES_REPO_VERSION": str(
+                        self.use_qubes_repo.get("version", None)
+                    ),
+                    "USE_QUBES_REPO_TESTING": "1"
+                    if self.use_qubes_repo.get("testing", None)
+                    else "0",
+                }
+            )
 
     def get_artifacts_info(self, stage: str) -> Dict:
         fileinfo = self.get_templates_dir() / f"{self.template.name}.{stage}.yml"

--- a/qubesbuilder/plugins/template_rpm/packages_fedora.list
+++ b/qubesbuilder/plugins/template_rpm/packages_fedora.list
@@ -87,4 +87,5 @@ zip
 --exclude=webkit2gtk3-plugin-process-gtk2
 --exclude=xdg-desktop-portal*
 --exclude=xorg-x11-drv-nouveau
+--exclude=wireplumber
 --exclude=yum-utils

--- a/qubesbuilder/plugins/template_rpm/packages_fedora_minimal.list
+++ b/qubesbuilder/plugins/template_rpm/packages_fedora_minimal.list
@@ -8,4 +8,5 @@ sudo
 --exclude=firewall-config,firewalld
 --exclude=gnome-boxes
 --exclude=yum-utils
+--exclude=wireplumber
 --exclude=pipewire-*

--- a/qubesbuilder/plugins/template_rpm/packages_fedora_xfce.list
+++ b/qubesbuilder/plugins/template_rpm/packages_fedora_xfce.list
@@ -75,5 +75,6 @@ zip
 --exclude=xfce4-sensors-plugin
 --exclude=xfce4-screensaver
 --exclude=xorg-x11-drv-nouveau
+--exclude=wireplumber
 --exclude=yum-utils
 --exclude=pipewire-pulseaudio


### PR DESCRIPTION
Few simple fixed.
TODO:

- [ ] there needs to be a way to set `TEMPLATE_ROOT_WITH_PARTITIONS`
- [ ] there needs to be a way to set `TEMPLATE_ROOT_SIZE`
- [ ] consider a setting for changing default mirrors?
- [x] consider dropping `DISCARD_PREPARED_IMAGE` setting at all, and always use `mv` instead of `cp`
- [ ] template version should not include `Z` from the timestamp
- [ ] missing github issue on success (created on build start, then commented on completion)