### PR TITLE
Dependencies: add mock and put qubes-gpg-split optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ sudo dnf install python3-packaging createrepo_c devscripts gpg python3-pyyaml 
 Debian:
 
 ```bash
-$ sudo apt install python3-packaging createrepo-c devscripts gpg python3-yaml rpm docker python3-docker reprepro python3-pathspec mktorrent openssl tree python3-setuptools python3-lxml mock
+$ sudo apt install python3-packaging createrepo-c devscripts gpg python3-yaml rpm docker python3-docker reprepro python3-pathspec mktorrent openssl tree python3-setuptools python3-lxml
 ```
 
 If your host OS is QubesOS, install `qubes-gpg-split`.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ Local, and Qubes executors are available.
 Fedora:
 
 ```bash
-$ sudo dnf install python3-packaging createrepo_c devscripts gpg qubes-gpg-split python3-pyyaml rpm docker python3-docker podman python3-podman reprepro python3-pathspec rpm-sign mktorrent openssl tree
+$ sudo dnf install python3-packaging createrepo_c devscripts gpg python3-pyyaml rpm docker python3-docker podman python3-podman reprepro python3-pathspec rpm-sign mktorrent openssl tree mock
 ```
 
 Debian:
 
 ```bash
-$ sudo apt install python3-packaging createrepo-c devscripts gpg qubes-gpg-split python3-yaml rpm docker python3-docker reprepro python3-pathspec mktorrent openssl tree python3-setuptools python3-lxml
+$ sudo apt install python3-packaging createrepo-c devscripts gpg python3-yaml rpm docker python3-docker reprepro python3-pathspec mktorrent openssl tree python3-setuptools python3-lxml mock
 ```
+
+If your host OS is QubesOS, install `qubes-gpg-split`.
 
 Install `mkmetalink`:
 


### PR DESCRIPTION
Hello,

When using this builder on a Fedora 37 host, I encountered two issues:

- dependency `mock` is missing
- dependency `qubes-gpg-split` is not available and useful when the host OS is not QubesOS

I only tested on Fedora 37, ~but I suppose it's similar on Debian~ see https://github.com/fepitre/qubes-builderv2/issues/56 for Debian.

Thanks!
