### PR TITLE
plugins: drop retrocompatibility part

### DIFF
--- a/qubesbuilder/plugins/__init__.py
+++ b/qubesbuilder/plugins/__init__.py
@@ -324,13 +324,6 @@ class DistributionComponentPlugin(DistributionPlugin, ComponentPlugin):
         self._parameters[stage]["build"] = [
             PackagePath(build) for build in self._parameters[stage].get("build", [])
         ]
-        # For retro-compatibility
-        if self.dist.type == "rpm":
-            self._parameters[stage]["build"] += [
-                PackagePath(spec)
-                for spec in self._parameters[stage].get("spec", [])
-                if PackagePath(spec) not in self._parameters["build"]
-            ]
         # Check conflicts when mangle paths
         mangle_builds = [
             build.mangle() for build in self._parameters[stage].get("build", [])


### PR DESCRIPTION
We should not have any more "spec" in .qubesbuilder